### PR TITLE
fix: add concurrency guard to claude-pr-shepherd to prevent double-merges

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -5,6 +5,10 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: claude-pr-shepherd
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

Adds a `concurrency:` group to `.github/workflows/claude-pr-shepherd.yml` so at most one shepherd instance runs at a time. New triggers queue behind the running one rather than being dropped (`cancel-in-progress: false`).

```yaml
concurrency:
  group: claude-pr-shepherd
  cancel-in-progress: false
```

**Problem:** The shepherd runs on a 15-minute cron with no concurrency guard. If a run takes >15 minutes, a second instance starts while the first is still executing. Both can observe the same open PR and attempt to merge it, causing double-merge attempts.

**Fix:** Only one shepherd instance runs at a time; new triggers queue behind the running one.

Closes #2

Generated with [Claude Code](https://claude.ai/code)