### PR TITLE
fix: anchor breaking-change regex to conventional commit type token

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -27,7 +27,7 @@ jobs:
           # Analyze latest commit message
           MSG=$(git log -1 --pretty=%s)
 
-          if echo "$MSG" | grep -qE "BREAKING CHANGE|!:"; then
+          if echo "$MSG" | grep -qE "BREAKING CHANGE|^[a-z]+(\(.+\))?!:"; then
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
           elif echo "$MSG" | grep -qE "^feat(\(.+\))?:"; then
             MINOR=$((MINOR + 1)); PATCH=0


### PR DESCRIPTION
## Summary

Fixes the regex pattern in auto-tag.yml that previously matched '\!:' anywhere in a commit message body, causing false major version bumps.

**Change:** .github/workflows/auto-tag.yml line 30

- Before: grep -qE "BREAKING CHANGE|\!:"
- After: grep -qE "BREAKING CHANGE|^[a-z]+(\(.+\))?\!:"

The new pattern anchors the \!: check to the start of the line and requires a valid conventional commit type token (e.g., feat\!:, fix(scope)\!:), matching the Conventional Commits spec.

Closes #3

Generated with [Claude Code](https://claude.ai/code)