### PR TITLE
feat: create GitHub Release with auto-generated notes after tagging

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create semantic version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get latest tag or start at v0.0.0
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "v0.0.0")
@@ -42,3 +44,6 @@ jobs:
           git tag $NEW_TAG
           git push origin $NEW_TAG
           echo "Tagged: $NEW_TAG"
+          gh release create "$NEW_TAG" \
+            --generate-notes \
+            --title "$NEW_TAG"


### PR DESCRIPTION
## Summary

After pushing a semantic version tag in auto-tag.yml, now also calls 'gh release create' with --generate-notes and --title. Added GH_TOKEN env var to the step so gh can authenticate. No new permissions needed since contents: write is already declared.

## Changes

.github/workflows/auto-tag.yml:
- Added env GH_TOKEN env var to the tagging step
- Added 'gh release create NEW_TAG --generate-notes --title NEW_TAG' after 'git push origin NEW_TAG'

Closes #8

Generated with Claude Code https://claude.ai/code