### PR TITLE
fix: handle merge conflicts in claude-pr-shepherd by prompting Claude to rebase

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -36,9 +36,11 @@ jobs:
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }}
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
-            3. If CI passes and reviewDecision is not CHANGES_REQUESTED, merge:
+            3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
+               gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
+            4. If CI passes and reviewDecision is not CHANGES_REQUESTED, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
-            4. If reviewDecision is CHANGES_REQUESTED, post a comment:
+            5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
 
             Use --repo ${{ github.repository }} on every gh command.


### PR DESCRIPTION
## Summary

- Adds an explicit conflict-handling step (step 3) to the `claude-pr-shepherd.yml` prompt
- When `mergeable` is `false`, the shepherd now posts a comment `@claude this PR has merge conflicts. Please rebase onto main and push an update.` and skips to the next PR
- The `@claude` trigger in the comment causes `claude.yml` to automatically handle the rebase
- Renumbers the existing steps 3→4 and 4→5 to accommodate the new step

## Before

Conflicted PRs were silently skipped every 15 minutes with no feedback to the author, causing PRs to stall indefinitely.

## After

Conflicted PRs get a targeted `@claude` comment that closes the feedback loop and triggers automatic rebasing.

Closes #9

Generated with [Claude Code](https://claude.ai/code)
