### PR TITLE
feat: handle merge conflicts in claude-pr-shepherd by prompting Claude to rebase

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -36,9 +36,11 @@ jobs:
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }}
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
-            3. If CI passes and reviewDecision is not CHANGES_REQUESTED, merge:
+            3. If CI passes and reviewDecision is not CHANGES_REQUESTED and mergeable is not false, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             4. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
+            5. If mergeable is false (merge conflicts exist), post a comment:
+               gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
 
             Use --repo ${{ github.repository }} on every gh command.


### PR DESCRIPTION
## Summary

- Adds an explicit conflict-handling branch (step 5) to the claude-pr-shepherd.yml prompt
- When a PR has mergeable == false, the shepherd now posts a @claude comment instructing Claude to rebase onto main
- Guards the merge step (step 3) to skip PRs with merge conflicts, preventing failed merge attempts
- Closes the feedback loop: conflicted PRs no longer stall silently

## Changes

.github/workflows/claude-pr-shepherd.yml:
- Step 3 updated: added 'and mergeable is not false' guard before merging
- Step 5 added: posts '@claude this PR has merge conflicts. Please rebase onto main and push an update.' when mergeable is false

Closes #9

Generated with [Claude Code](https://claude.ai/code)