### PR TITLE
feat: submit formal APPROVE/REQUEST_CHANGES review decision in claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,5 +35,13 @@ jobs:
             Post review comments inline on the diff using the GitHub API.
             Be concise. Focus on significant issues only.
             # CUSTOMIZE: Add stack-specific review criteria here
+
+            After posting inline comments, submit a formal review decision using the GitHub API.
+            Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).
+            If no blocking issues:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
+            If blocking issues found:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
+            Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, or breaking changes. Use APPROVE for minor issues, style comments, or suggestions.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"


### PR DESCRIPTION
## Summary

Updates .github/workflows/claude-code-review.yml to instruct Claude to submit a formal GitHub review decision after posting inline diff comments:
- If no blocking issues found, submit APPROVE via GitHub API
- If blocking issues found, submit REQUEST_CHANGES via GitHub API

## Problem Solved

Previously, the review workflow only posted inline comments but never submitted a formal review decision, so reviewDecision was always null. The PR shepherd gates merges on reviewDecision != CHANGES_REQUESTED, which meant it merged every PR immediately after CI passed, bypassing the code review gate entirely.

## Changes

.github/workflows/claude-code-review.yml: extended the prompt to include instructions for submitting a formal review decision via the GitHub API after posting inline comments.

Closes #7

Generated with [Claude Code](https://claude.ai/code)