### PR TITLE
feat: submit formal APPROVE/REQUEST_CHANGES review decision

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,5 +35,14 @@ jobs:
             Post review comments inline on the diff using the GitHub API.
             Be concise. Focus on significant issues only.
             # CUSTOMIZE: Add stack-specific review criteria here
+
+            After posting any inline comments, submit a formal GitHub review decision:
+            1. Get the PR info: `gh pr view --json number,baseRepository`
+            2. Submit a formal review using the reviews endpoint:
+               - If no blocking issues found → APPROVE:
+                 `gh api repos/{owner}/{repo}/pulls/{number}/reviews --method POST --raw-field body="LGTM — no blocking issues found." --field event=APPROVE`
+               - If blocking issues found → REQUEST_CHANGES:
+                 `gh api repos/{owner}/{repo}/pulls/{number}/reviews --method POST --raw-field body="Blocking issues found. See inline comments." --field event=REQUEST_CHANGES`
+            You must submit exactly one formal review decision (APPROVE or REQUEST_CHANGES) before finishing.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"


### PR DESCRIPTION
## Summary

Fixes the code review workflow so it functions as a real gate in the factory loop, not just decorative comments.

**Changes to .github/workflows/claude-code-review.yml:**
- Extended the review prompt with instructions to submit a formal GitHub review decision after posting inline comments
- If no blocking issues -> submit APPROVE via gh api
- If blocking issues found -> submit REQUEST_CHANGES via gh api

**Why this matters:**
The shepherd (claude-pr-shepherd.yml) gates merges on reviewDecision != CHANGES_REQUESTED. Since the review workflow previously never submitted a formal decision, reviewDecision was always null, meaning the shepherd merged every PR immediately after CI — bypassing code review entirely. This fix closes that gap.

Closes #7

Generated with [Claude Code](https://claude.ai/code)