### PR TITLE
fix: require explicit APPROVED review before merging in PR shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -38,9 +38,10 @@ jobs:
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
-            4. If CI passes and reviewDecision is not CHANGES_REQUESTED, merge:
+            4. If CI passes and reviewDecision is APPROVED, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
+            6. If reviewDecision is null or REVIEW_REQUIRED, skip and wait for the review workflow to complete
 
             Use --repo ${{ github.repository }} on every gh command.


### PR DESCRIPTION
## Summary

- Changes the merge condition in `claude-pr-shepherd.yml` from opt-out (`reviewDecision is not CHANGES_REQUESTED`) to opt-in (`reviewDecision is APPROVED`)
- Adds explicit skip case for `null` or `REVIEW_REQUIRED` review decisions so PRs without a formal review are held rather than merged

## Changes

`.github/workflows/claude-pr-shepherd.yml` step 4 and new step 6:
- Step 4: `If CI passes and reviewDecision is APPROVED, merge`
- Step 6: `If reviewDecision is null or REVIEW_REQUIRED, skip and wait for the review workflow to complete`

Closes #15

Generated with [Claude Code](https://claude.ai/code)