### PR TITLE
feat: add per-issue/PR concurrency group to claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,10 @@ permissions:
   id-token: write
   actions: read
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a `concurrency:` block at the workflow level of `.github/workflows/claude.yml` to prevent duplicate implementations when multiple `@claude` triggers fire in quick succession on the same issue or PR.

## Changes

- Added `concurrency:` block between `permissions:` and `jobs:` in `.github/workflows/claude.yml`
- Uses `cancel-in-progress: false` so queued runs are not dropped — each trigger is handled in order
- Falls back to `github.run_id` for events where neither `issue.number` nor `pull_request.number` is set (e.g., `pull_request_review` events)

## References

Closes #19

Generated with [Claude Code](https://claude.ai/code)
