### PR TITLE
fix: guard against merging PRs whose CI checks have not yet started

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -35,10 +35,15 @@ jobs:
 
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }}
+               Evaluate the output carefully before proceeding:
+               - If the output is empty (no checks listed), CI has not started yet → SKIP this PR entirely, do not merge
+               - If any check shows a status of "pending" or "in_progress", CI is still running → SKIP this PR, do not merge
+               - If any check shows a status of "fail", CI has failed → do NOT merge
+               - CI passes only when: at least one check is present AND every check shows "pass"
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
-            4. If CI passes and reviewDecision is APPROVED, merge:
+            4. If CI passes (at least one check present, all checks completed with "pass" status) and reviewDecision is APPROVED, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"


### PR DESCRIPTION
## Problem

`gh pr checks` returns an empty list when checks have not registered yet (e.g., a freshly opened PR). The shepherd was interpreting zero failures as passing CI, potentially merging PRs before any checks ran.

## Changes

Updated the shepherd prompt in `.github/workflows/claude-pr-shepherd.yml` (lines 36–50) to explicitly require at least one completed passing check before merging:

- **Empty output** → CI has not started yet → SKIP, do not merge
- **Any check pending/in_progress** → CI still running → SKIP, do not merge  
- **Any check failed** → do NOT merge
- **All checks pass (≥1 present)** → CI passes, proceed with merge decision

The merge condition in step 4 now reads: *"If CI passes (at least one check present, all checks completed with 'pass' status) and reviewDecision is APPROVED, merge"*

## References

Closes #20

Generated with [Claude Code](https://claude.ai/code)