### PR TITLE
fix: allow bot-authored issues to trigger Claude auto-assign

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -28,9 +28,13 @@ jobs:
 
           # CUSTOMIZE: Authorization check — pick one:
 
-          # Option 1: Restrict to specific username(s)
+          # Option 1: Restrict to specific username(s) and trusted bots
           ALLOWED_USERS="greynewell"
-          if echo "$ALLOWED_USERS" | grep -qw "$ISSUE_AUTHOR"; then
+          ALLOWED_BOTS="github-actions[bot] claude[bot]"
+          # Use grep -w for regular users; use grep -F with space padding for bots
+          # because [bot] suffix contains regex metacharacters that break grep -w
+          if echo "$ALLOWED_USERS" | grep -qw "$ISSUE_AUTHOR" || \
+             echo " $ALLOWED_BOTS " | grep -qF " $ISSUE_AUTHOR "; then
             AUTHORIZED=true
           else
             AUTHORIZED=false


### PR DESCRIPTION
## Summary

- Adds ALLOWED_BOTS containing github-actions[bot] and claude[bot] to the authorization check in claude-auto-assign.yml
- Updates the if condition to authorize both human users (via grep -w) and trusted bots (via grep -F with space padding)
- Uses grep -F for the bots check because [bot] contains regex metacharacters that cause grep -w to misinterpret the pattern

## Why

Factory scanners (claude-proactive.yml, claude-self-improve.yml) file issues as github-actions[bot] or claude[bot]. The old check only allowed greynewell, so bot-authored issues were silently skipped — breaking the core self-improvement loop (scan → issue → implement → PR → merge).

Closes #28

Generated with [Claude Code](https://claude.ai/code)