### PR TITLE
fix: deduplicate merge-conflict comments in PR shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -41,7 +41,10 @@ jobs:
                - If any check shows a status of "fail", CI has failed → do NOT merge
                - CI passes only when: at least one check is present AND every check shows "pass"
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
-            3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
+            3. If mergeable is false (merge conflicts exist), before posting check for duplicate comments:
+               Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '.[].body'
+               If any existing comment body contains the phrase "merge conflicts", skip to the next PR without posting.
+               Otherwise post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
             4. If CI passes (at least one check present, all checks completed with "pass" status) and reviewDecision is APPROVED, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch


### PR DESCRIPTION
## Summary

- Modifies step 3 of the `claude-pr-shepherd.yml` prompt to check for existing comments before posting a merge-conflict notice
- Uses `gh api repos/OWNER/REPO/issues/NUMBER/comments` to fetch existing PR comments
- Skips posting if any comment body already contains "merge conflicts"
- Prevents the 15-minute scheduled shepherd from spamming duplicate comments on PRs with unresolved conflicts

## Changes

**`.github/workflows/claude-pr-shepherd.yml`** — step 3 updated to deduplicate before posting.

Before posting a merge-conflict comment, Claude now runs:
  gh api repos/OWNER/REPO/issues/NUMBER/comments --jq '.[].body'
and skips the comment if any existing body contains "merge conflicts".

Closes #30

Generated with [Claude Code](https://claude.ai/code)
