### PR TITLE
feat: notify Claude when CI fails on a PR

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -38,7 +38,11 @@ jobs:
                Evaluate the output carefully before proceeding:
                - If the output is empty (no checks listed), CI has not started yet → SKIP this PR entirely, do not merge
                - If any check shows a status of "pending" or "in_progress", CI is still running → SKIP this PR, do not merge
-               - If any check shows a status of "fail", CI has failed → do NOT merge
+               - If any check shows a status of "fail", CI has failed → do NOT merge; instead check for duplicate comments:
+                 Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '.[].body'
+                 If any existing comment body contains the phrase "CI checks are failing", skip to the next PR without posting.
+                 Otherwise post a comment and skip to the next PR:
+                 gh pr comment <number> --repo ${{ github.repository }} --body "@claude CI checks are failing on this PR. Please review the failed checks and push a fix."
                - CI passes only when: at least one check is present AND every check shows "pass"
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), before posting check for duplicate comments:


### PR DESCRIPTION
## Summary

- Expands the CI failure branch in the shepherd prompt to notify Claude instead of silently skipping
- Deduplicates notifications: checks existing PR comments for 'CI checks are failing' before posting, matching the existing merge-conflict pattern
- Posts '@claude CI checks are failing on this PR. Please review the failed checks and push a fix.' when no existing notification is found

## Changes

File: .github/workflows/claude-pr-shepherd.yml (lines 41-45)

Before: a single bullet stating CI has failed, do not merge (no follow-up)
After: deduplication check + comment post + skip, identical in structure to the merge-conflict handler at lines 48-52.

Closes #33

Generated with [Claude Code](https://claude.ai/code)