### PR TITLE
feat: add gh pr list/view tools and stuck-PR detection to proactive scanner

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.
@@ -42,6 +42,13 @@ jobs:
               security scanning, performance regression, notification hooks, etc.)
             - Ways to make the self-loop tighter (concurrency, retry logic, bot triggers)
             - CLAUDE.md instructions that are unclear or missing
+
+            Also check the real-world health of the factory loop by running:
+              gh pr list --repo ${{ github.repository }} --state open --json number,title,createdAt,reviewDecision
+            Flag and file an issue for each of the following (if no open issue already covers it):
+            - Any PR that has been open > 2 days without a review decision (scanner is blind or
+              the review workflow is broken)
+            - Any PR whose reviewDecision is APPROVED but has not been merged (shepherd may be stuck)
 
             **Pass 2 — General codebase issues**:
             - Logic errors, race conditions, unhandled exceptions


### PR DESCRIPTION
## Summary

- Adds `Bash(gh pr list:*)` and `Bash(gh pr view:*)` to the `claude_args` allowed tools in `claude-proactive.yml`
- Extends the Pass 1 prompt with a new block that runs `gh pr list` and flags stuck PRs:
  - PRs open > 2 days without a review decision
  - PRs with `reviewDecision: APPROVED` that have not been merged (shepherd may be stuck)
- Uses `${{ github.repository }}` so the command targets the correct repo at runtime

## Changes

Adds two new allowed tools and a new "factory health" sub-section to the Pass 1 prompt. The `gh pr list` command outputs JSON with `number`, `title`, `createdAt`, and `reviewDecision` fields so the scanner can reason about staleness and approval state.

Closes #34

Generated with [Claude Code](https://claude.ai/code)