### PR TITLE
feat: add changelog generation workflow on release publish

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   update-changelog:
@@ -24,7 +23,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Read,Write,Edit"'
+          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
           prompt: |
             Update CHANGELOG.md for the just-published release ${{ github.event.release.tag_name }}.
 
@@ -48,4 +47,5 @@ jobs:
                  git config user.email "github-actions[bot]@users.noreply.github.com"
                  git add CHANGELOG.md
                  git commit -m "chore: update changelog for ${{ github.event.release.tag_name }}"
+                 git pull --rebase origin main
                  git push origin main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/changelog.yml` that triggers on `release: [published]`
- Uses `claude-code-action` to fetch release notes via `gh release view`, prepend a new `## vX.Y.Z — YYYY-MM-DD` entry to `CHANGELOG.md`, and commit/push directly to main
- Uses `chore:` commit prefix so `auto-tag.yml` does not create an additional tag for the changelog update

## How it works

1. Triggered when a GitHub release is published (after `auto-tag.yml` creates the tag and release)
2. Checks out `main` branch
3. Claude fetches the release notes, prepends a formatted entry to `CHANGELOG.md` (creating the file if absent), and commits with `chore: update changelog for vX.Y.Z`
4. Pushes directly to main — no extra tag is created because `chore:` commits are skipped by `auto-tag.yml`

Closes #35

Generated with [Claude Code](https://claude.ai/code)