### PR TITLE
fix: add github_token to proactive and self-improve scanners

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -23,6 +23,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
           claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Read,Glob,Grep"'
           prompt: |

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -23,6 +23,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
           claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Read,Glob,Grep"'
           prompt: |


### PR DESCRIPTION
## Problem

Both `claude-proactive.yml` and `claude-self-improve.yml` were missing `github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}` in their `anthropics/claude-code-action@v1` steps.

Without this, the `gh` CLI uses the default `GITHUB_TOKEN` (runner token). Per GitHub's documented behaviour, events triggered by `GITHUB_TOKEN` do not create new workflow runs — so issues filed by these scanners never triggered `claude-auto-assign.yml`, silently breaking the self-improvement loop.

## Fix

Added `github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}` to:
- `.github/workflows/claude-proactive.yml` — `Run Claude Proactive Scanner` step
- `.github/workflows/claude-self-improve.yml` — `Run Claude Weekly Deep Scanner` step

This matches the existing pattern in `claude-pr-shepherd.yml` and `claude.yml`.

Closes #40

Generated with [Claude Code](https://claude.ai/code)
