### PR TITLE
feat: protect factory-assigned issues from stale auto-close

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -54,6 +54,14 @@ jobs:
           if [ "$AUTHORIZED" = "true" ]; then
             gh issue comment $ISSUE_NUMBER --repo $REPO \
               --body "@claude please implement this issue"
+
+            # Ensure the claude-task label exists, then apply it so stale.yml
+            # won't auto-close factory-assigned issues before Claude implements them
+            gh label create claude-task \
+              --repo "$REPO" \
+              --description "Assigned to Claude for implementation" \
+              --color "7057ff" 2>/dev/null || true
+            gh issue edit $ISSUE_NUMBER --repo $REPO --add-label claude-task
           else
             echo "User $ISSUE_AUTHOR not authorized, skipping"
           fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,7 +44,7 @@ jobs:
             inactivity. If this work is still needed, please reopen or open a new PR.
 
           # Exempt labels — issues/PRs with these labels will not go stale
-          exempt-issue-labels: "in-progress,blocked,pinned"
+          exempt-issue-labels: "in-progress,blocked,pinned,claude-task"
           exempt-pr-labels: "in-progress,blocked,pinned"
 
           # Exempt draft PRs from stale marking (they may be actively in progress)


### PR DESCRIPTION
## Summary

- `claude-auto-assign.yml`: After posting the `@claude please implement this issue` comment, creates the `claude-task` label (idempotent — uses `|| true`) and applies it to the issue.
- `stale.yml`: Adds `claude-task` to `exempt-issue-labels` so issues carrying that label are never marked stale or auto-closed.

This prevents valid improvement issues filed by `claude-proactive.yml` and `claude-self-improve.yml` from being closed before Claude processes them, eliminating the churn of re-filing and lost history.

Fixes #46

Generated with [Claude Code](https://claude.ai/code)
