### PR TITLE
docs: add 'Closes #N' instruction to PR body guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,13 @@ gh pr create \
   --head <branch>
 ```
 
+The PR `--body` must include `Closes #<issue-number>` so GitHub auto-closes the originating
+issue on merge. Example body footer:
+
+```
+Closes #42
+```
+
 Always run this as the final step. The PR must exist before marking the task complete.
 
 ## Issues


### PR DESCRIPTION
## Summary

Add an explicit instruction to CLAUDE.md requiring that PR bodies always include `Closes #<issue-number>` so GitHub auto-closes the originating issue on merge.

Without this instruction, Claude-created PRs don't close their originating issues, leading to:
- Polluted open issue backlog with already-implemented items
- The proactive/weekly scanners detecting still-open issues and filing duplicate work

## Changes

Updated the **Pull Requests** section of CLAUDE.md to add:
> The PR `--body` must include `Closes #<issue-number>` so GitHub auto-closes the originating issue on merge.

With an example showing `Closes #42` as a body footer.

Closes #50

Generated with [Claude Code](https://claude.ai/code)