### PR TITLE
chore: add dependabot.yml for automated GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable Dependabot's automated version update PRs for the `github-actions` ecosystem.

### Configuration

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
    commit-message:
      prefix: chore
```

- **Ecosystem**: `github-actions`
- **Schedule**: Weekly
- **Commit prefix**: `chore` (no version bump per Conventional Commits)

This will create automated PRs when `actions/checkout`, `anthropics/claude-code-action`, and other pinned actions release new versions, which the factory loop can then auto-review and merge.

Closes #51

Generated with [Claude Code](https://claude.ai/code)