### PR TITLE
fix: remove unused 'assigned' trigger from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary

Removes the `assigned` event type from the `issues` trigger in `.github/workflows/claude.yml`.

### Problem

The `assigned` trigger type was dead code — no workflow in this repo assigns issues to GitHub users. `claude-auto-assign.yml` triggers via `issue_comment`, not via assignment. This created an unnecessary attack surface: a bad actor could trigger Claude by assigning an issue whose body contains `@claude`, bypassing the authorization check in `claude-auto-assign.yml`.

### Change

```yaml
# Before
issues:
  types: [opened, assigned]

# After
issues:
  types: [opened]
```

Closes #52

Generated with [Claude Code](https://claude.ai/code)