### PR TITLE
fix: add Bash(git config:*) to allowed tools in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,5 +39,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
           # CUSTOMIZE: Add your stack's build/lint/test commands to the allowedTools list above


### PR DESCRIPTION
## Summary

Add `Bash(git config:*)` to the `claude_args` allowed tools list in `.github/workflows/claude.yml`.

GitHub Actions runners have no global `git user.name`/`git user.email` configured. Without `Bash(git config:*)` in the allowed tools, Claude cannot set its git identity before committing, causing an 'Author identity unknown' error. This change inserts `Bash(git config:*)` alongside the other git commands already permitted in the list.

The fix mirrors the approach already used in `changelog.yml` (lines 46–47) which explicitly runs `git config` before committing.

Generated with [Claude Code](https://claude.ai/code)

Closes #57