### PR TITLE
fix: fetch PR diff before review in claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,10 @@ jobs:
           allowed_bots: "claude[bot],github-actions[bot]"
           claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"'
           prompt: |
+            Step 0: Fetch the PR diff by running:
+              gh pr view ${{ github.event.pull_request.number }} --patch --repo ${{ github.repository }}
+            Read the full output to understand all changed files and lines before proceeding.
+
             Review this pull request for:
             1. Correctness and logic errors
             2. Security vulnerabilities


### PR DESCRIPTION
## Summary

The review prompt in `claude-code-review.yml` never instructed Claude to fetch the actual PR diff, resulting in shallow reviews based only on the PR title and description.

## Changes

Added a **Step 0** at the top of the review prompt that instructs Claude to run:
```
gh pr view <PR_NUMBER> --patch --repo <REPO>
```
before performing the review. This ensures Claude reads all changed files and lines before evaluating correctness, security, and breaking changes.

Closes #58

Generated with [Claude Code](https://claude.ai/code)