### PR TITLE
docs: instruct Claude to label PRs with claude-task after creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,14 @@ issue on merge. Example body footer:
 Closes #42
 ```
 
+After creating a PR, apply the `claude-task` label so the stale workflow does not auto-close it:
+
+```
+gh issue edit <PR-number> --repo OWNER/REPO --add-label claude-task
+```
+
+(GitHub treats PRs as issues for the label API, so `gh issue edit` works on PR numbers.)
+
 Always run this as the final step. The PR must exist before marking the task complete.
 
 ## Issues


### PR DESCRIPTION
## Summary

- Adds an explicit instruction to CLAUDE.md telling Claude to apply the `claude-task` label to every PR it opens after creation
- Uses `gh issue edit <PR-number> --add-label claude-task` (GitHub treats PRs as issues for the label API)
- Prevents the stale workflow from auto-closing Claude-created PRs that sit open during backlog or review deadlock

Closes #64

Generated with [Claude Code](https://claude.ai/code)