### PR TITLE
fix: scan all commits since last tag for version bump

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -26,17 +26,27 @@ jobs:
           MINOR=$(echo $LATEST | cut -d. -f2)
           PATCH=$(echo $LATEST | cut -d. -f3)
 
-          # Analyze latest commit message
-          MSG=$(git log -1 --pretty=%s)
+          # Analyze all commits since the last tag (handles multi-commit rebase merges)
+          if git rev-parse "$LATEST" >/dev/null 2>&1; then
+            MSGS=$(git log "${LATEST}..HEAD" --pretty=%s)
+          else
+            MSGS=$(git log --pretty=%s)
+          fi
 
-          if echo "$MSG" | grep -qE "BREAKING CHANGE|^[a-z]+(\(.+\))?!:"; then
+          if [ -z "$MSGS" ]; then
+            echo "No new commits since $LATEST"
+            exit 0
+          fi
+
+          if echo "$MSGS" | grep -qE "BREAKING CHANGE|^[a-z]+(\(.+\))?!:"; then
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-          elif echo "$MSG" | grep -qE "^feat(\(.+\))?:"; then
+          elif echo "$MSGS" | grep -qE "^feat(\(.+\))?:"; then
             MINOR=$((MINOR + 1)); PATCH=0
-          elif echo "$MSG" | grep -qE "^fix(\(.+\))?:"; then
+          elif echo "$MSGS" | grep -qE "^fix(\(.+\))?:"; then
             PATCH=$((PATCH + 1))
           else
-            echo "No version bump needed for: $MSG"
+            echo "No version bump needed. Commits since $LATEST:"
+            echo "$MSGS"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Replace `git log -1` with `git log "${LATEST}..HEAD"` to scan all commits since the previous tag
- Apply the highest-priority bump found across all commits: BREAKING CHANGE/feat! > feat: > fix:
- Handle edge case where no previous tag exists (uses all commits in that case)
- Emit the commit list in the no-bump path for easier debugging

## Problem Fixed

When a PR with multiple commits is merged via `--rebase`, only the last commit was read. If a `feat:` commit was followed by a `fix:` commit (e.g., addressing review feedback), the intended MINOR bump was silently lost and only a PATCH bump was applied.

## Changes

`.github/workflows/auto-tag.yml` — updated the "Create semantic version tag" bash script.

Closes #63

Generated with [Claude Code](https://claude.ai/code)