### PR TITLE
fix: compare review comment timestamp against last commit in step 6 de-dup

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -60,10 +60,13 @@ jobs:
                a. Check when the PR was last updated: gh pr view <number> --repo ${{ github.repository }} --json updatedAt
                b. Compute the age in seconds: updated_seconds=$(date -d "<updatedAt value>" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "<updatedAt value>" +%s); now=$(date +%s); age=$((now - updated_seconds))
                c. If age is greater than 7200 (2 hours):
-                  - Check for duplicate comments to avoid spamming:
-                    gh api repos/${{ github.repository }}/issues/<number>/comments --jq '.[].body'
-                  - If any existing comment body contains the phrase "please review this PR", skip to the next PR without posting.
-                  - Otherwise post a comment to re-trigger the review workflow:
+                  - Get the timestamp of the most recent "please review this PR" comment:
+                    Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '[.[] | select(.body | contains("please review this PR"))] | max_by(.created_at) | .created_at'
+                    (Returns an ISO timestamp string, or null if no such comment exists)
+                  - Get the timestamp of the most recent commit to this PR:
+                    Run: gh pr view <number> --repo ${{ github.repository }} --json commits --jq '.commits[-1].committedDate'
+                  - If the most recent "please review this PR" comment timestamp is non-empty AND is more recent than (or equal to) the last commit timestamp, skip to the next PR without posting (de-dup: the existing trigger was already posted after the latest push).
+                  - Otherwise (no such comment exists, OR the comment predates the latest commit push), post a comment to re-trigger the review workflow:
                     gh pr comment <number> --repo ${{ github.repository }} --body "@claude please review this PR and submit a formal review decision (APPROVE or REQUEST_CHANGES)."
                d. Otherwise skip and wait for the review workflow to complete
 


### PR DESCRIPTION
## Summary

- Replaces the simple string-match de-dup in step 6 of the PR shepherd with a timestamp comparison
- Fetches the timestamp of the most recent "please review this PR" comment using `max_by(.created_at)`
- Fetches the timestamp of the PR's most recent commit via `gh pr view --json commits`
- Only skips posting a new trigger if the existing comment is **newer than** the last commit; otherwise treats it as stale and posts a new trigger
- Prevents the permanent suppression bug where a pre-existing review comment would block re-triggering after new commits were pushed

Closes #69

Generated with [Claude Code](https://claude.ai/code)