### PR TITLE
feat: auto-label Claude-created PRs with claude-task to prevent stale closure

### DIFF
--- a/.github/workflows/claude-pr-label.yml
+++ b/.github/workflows/claude-pr-label.yml
@@ -1,0 +1,37 @@
+name: Claude PR Label
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add claude-task label to bot-created PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          BOT_AUTHORS="github-actions[bot] claude[bot]"
+
+          if echo " $BOT_AUTHORS " | grep -qF " $PR_AUTHOR "; then
+            echo "PR opened by $PR_AUTHOR — adding claude-task label"
+
+            # Ensure the label exists (idempotent)
+            gh label create claude-task \
+              --repo "$REPO" \
+              --description "Assigned to Claude for implementation" \
+              --color "7057ff" 2>/dev/null || true
+
+            # Apply the label to the PR
+            gh issue edit "$PR_NUMBER" --repo "$REPO" --add-label claude-task
+          else
+            echo "PR opened by $PR_AUTHOR — not a bot, skipping"
+          fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -45,7 +45,7 @@ jobs:
 
           # Exempt labels — issues/PRs with these labels will not go stale
           exempt-issue-labels: "in-progress,blocked,pinned,claude-task"
-          exempt-pr-labels: "in-progress,blocked,pinned"
+          exempt-pr-labels: "in-progress,blocked,pinned,claude-task"
 
           # Exempt draft PRs from stale marking (they may be actively in progress)
           exempt-draft-prs: true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/claude-pr-label.yml`: triggers on `pull_request.opened` and automatically applies the `claude-task` label to PRs opened by `github-actions[bot]` or `claude[bot]`, mirroring what `claude-auto-assign.yml` already does for issues
- Fix `.github/workflows/stale.yml` line 48: add `claude-task` to `exempt-pr-labels` so the label actually prevents stale marking and auto-closure of PRs (it was already in `exempt-issue-labels` but missing for PRs)

## Root cause

Two gaps existed:
1. No automation to apply `claude-task` to bot-created PRs (only a CLAUDE.md instruction that Claude often missed)
2. Even if the label was applied, `stale.yml` did not exempt PRs with `claude-task` from staleness — only issues were exempted

## Implementation

`claude-pr-label.yml` uses the same `grep -qF` pattern from `claude-auto-assign.yml` to safely match bot usernames containing `[bot]`. The label creation step is idempotent.

Closes #73

Generated with [Claude Code](https://claude.ai/code)
