### PR TITLE
fix: add actions/checkout step to claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

Add `actions/checkout@v4` step to `claude-code-review.yml` before the Claude Code Review step.

Without a checkout, the `Read`, `Glob`, and `Grep` tools listed in `claude_args` have no local files to operate on. Claude can only see what `gh pr view` and `gh api` return, missing surrounding code context (imports, call sites, consistency with the rest of the codebase).

This single-step fix mirrors the pattern already used in `claude.yml` and `claude-self-improve.yml`.

Closes #76

Generated with [Claude Code](https://claude.ai/code)