### PR TITLE
fix: check both issue title and body for @claude in auto-assign

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -16,12 +16,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Check if issue contains @claude
-          if ! echo "$ISSUE_BODY" | grep -q "@claude"; then
+          # Check if issue contains @claude in body or title
+          if ! echo "$ISSUE_BODY$ISSUE_TITLE" | grep -q "@claude"; then
             echo "Issue does not mention @claude, skipping"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Previously, `claude-auto-assign.yml` only checked `ISSUE_BODY` for `@claude`, which meant an issue with `@claude` only in the title would bypass the authorization gate while still triggering `claude.yml` directly.

### Changes
- Added `ISSUE_TITLE` to the env block
- Updated grep to check both body and title: `if ! echo "$ISSUE_BODY$ISSUE_TITLE" | grep -q "@claude"`

This closes the bypass gap referenced in issue #24.

Closes #82

Generated with [Claude Code](https://claude.ai/code)
