### PR TITLE
fix: increase issue list limit to 100 and add keyword search for duplicate detection

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -31,7 +31,12 @@ jobs:
             the factory — its workflows are the product. Improving them is the primary goal.
 
             Check existing open issues first to avoid duplicates:
-              gh issue list --state open --limit 50
+              gh issue list --state open --limit 100
+
+            Before filing each issue, also run a targeted keyword search to catch duplicates
+            even when the open issue count exceeds the list limit:
+              gh issue list --state open --search "keyword from proposed title" --limit 10
+            Only file an issue if neither check returns a matching open issue.
 
             Scan in two passes:
 

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -34,7 +34,12 @@ jobs:
             Take your time and be thorough.
 
             Check existing open issues first to avoid duplicates:
-              gh issue list --state open --limit 50
+              gh issue list --state open --limit 100
+
+            Before filing each issue, also run a targeted keyword search to catch duplicates
+            even when the open issue count exceeds the list limit:
+              gh issue list --state open --search "keyword from proposed title" --limit 10
+            Only file an issue if neither check returns a matching open issue.
 
             Perform the following four passes in order:
 


### PR DESCRIPTION
## Summary

- Increases `--limit 50` to `--limit 100` in both `claude-proactive.yml` and `claude-self-improve.yml` for the initial open issues fetch
- Adds a targeted keyword search step before filing each issue using `--search "keyword from proposed title" --limit 10` to catch duplicates even when the open issue count exceeds the list limit
- The existing `Bash(gh issue list:*)` glob in `claude_args` already covers the `--search` flag — no `allowed_tools` changes needed

## Details

Both workflows previously used `gh issue list --state open --limit 50` for duplicate detection. As the automated factory accumulates issues over time, this window shrinks relative to the backlog. The two-step approach (broad fetch + targeted keyword search) makes duplicate detection robust regardless of backlog size.

Closes #81

Generated with [Claude Code](https://claude.ai/code)
