### PR TITLE
fix: add Bash(gh pr checks:*) to allowedTools in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,5 +39,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
           # CUSTOMIZE: Add your stack's build/lint/test commands to the allowedTools list above


### PR DESCRIPTION
## Summary

Adds `Bash(gh pr checks:*)` to the `allowedTools` list in `.github/workflows/claude.yml` so Claude can run `gh pr checks <number>` when diagnosing CI failures.

Without this permission, Claude could only use `gh pr view` which provides a coarse status rollup — not the per-check names or failure details needed to target fixes accurately.

## Change

`.github/workflows/claude.yml` line 42: inserted `Bash(gh pr checks:*)` after `Bash(gh pr view:*)` in the `allowedTools` string.

Closes #85

Generated with [Claude Code](https://claude.ai/code)