### PR TITLE
fix: add ready_for_review trigger to claude-pr-label.yml

### DIFF
--- a/.github/workflows/claude-pr-label.yml
+++ b/.github/workflows/claude-pr-label.yml
@@ -2,7 +2,7 @@ name: Claude PR Label
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

Add `ready_for_review` to the trigger types in `claude-pr-label.yml` so the `claude-task` label is applied when a draft PR is converted to ready-for-review.

**Change made:**
```yaml
# Before
on:
  pull_request:
    types: [opened]

# After
on:
  pull_request:
    types: [opened, ready_for_review]
```

Without this fix, a Claude-created PR opened as a draft and later converted to ready-for-review would never receive the `claude-task` label, causing `stale.yml` to potentially auto-close it after 21 days of inactivity.

Closes #87

Generated with [Claude Code](https://claude.ai/code)