### PR TITLE
fix: add timeout-minutes: 10 to auto-tag job

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Add `timeout-minutes: 10` to the `auto-tag` job in `.github/workflows/auto-tag.yml` to prevent the job from hanging for up to 6 hours (the GitHub Actions default) if `git push origin $NEW_TAG` or `gh release create` stall due to network issues or GitHub API slowness.

## Change

```yaml
jobs:
  auto-tag:
    runs-on: ubuntu-latest
    timeout-minutes: 10  # added
```

A 10-minute timeout is generous for a tag + release operation, matching the recommendation in the issue.

Closes #92

Generated with [Claude Code](https://claude.ai/code)