### PR TITLE
fix: update changelog before tagging so tagged commit contains changelog entry

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,11 +15,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use PAT so git push of changelog commit to main is authorized
+          token: ${{ secrets.GH_WORKFLOW_TOKEN }}
 
       - name: Create semantic version tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Skip if this is an automated changelog update to prevent recursive triggering
+          HEAD_MSG=$(git log -1 --pretty=%s)
+          if echo "$HEAD_MSG" | grep -qE "^chore: update changelog"; then
+            echo "Skipping: this is an automated changelog update commit"
+            exit 0
+          fi
+
           # Get latest tag or start at v0.0.0
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "v0.0.0")
           MAJOR=$(echo $LATEST | cut -d. -f1 | tr -d 'v')
@@ -51,6 +60,36 @@ jobs:
           fi
 
           NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # Build changelog entry from commits since last tag (exclude automated changelog commits)
+          if git rev-parse "$LATEST" >/dev/null 2>&1; then
+            COMMIT_LIST=$(git log "${LATEST}..HEAD" --pretty="- %s" | grep -v "^- chore: update changelog" || true)
+          else
+            COMMIT_LIST=$(git log --pretty="- %s" | grep -v "^- chore: update changelog" || true)
+          fi
+
+          # Prepend new entry to CHANGELOG.md so the tagged commit always contains it
+          {
+            echo "## ${NEW_TAG} — ${TODAY}"
+            echo ""
+            echo "${COMMIT_LIST}"
+            if [ -f CHANGELOG.md ]; then
+              echo ""
+              cat CHANGELOG.md
+            fi
+          } > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
+
+          # Commit changelog update to main before creating the tag
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update changelog for ${NEW_TAG}"
+          git pull --rebase origin main
+          git push origin main
+
+          # Tag now points to the commit that includes the updated changelog
           git tag $NEW_TAG
           git push origin $NEW_TAG
           echo "Tagged: $NEW_TAG"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,8 +1,15 @@
 name: Changelog
 
 on:
-  release:
-    types: [published]
+  # Triggered manually to enrich a release's CHANGELOG entry with Claude-generated notes.
+  # Automatic changelog updates are now handled atomically inside auto-tag.yml before tagging,
+  # so that the tagged commit always contains the changelog entry for that version.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to generate changelog entry for (e.g. v1.2.3)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -25,19 +32,21 @@ jobs:
           allowed_bots: "claude[bot],github-actions[bot]"
           claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
           prompt: |
-            Update CHANGELOG.md for the just-published release ${{ github.event.release.tag_name }}.
+            Update CHANGELOG.md for the release ${{ github.event.inputs.tag_name }}.
 
             Steps:
             1. Fetch the release details:
-                 gh release view ${{ github.event.release.tag_name }} --json tagName,body
+                 gh release view ${{ github.event.inputs.tag_name }} --json tagName,body,publishedAt
 
             2. Read the current CHANGELOG.md if it exists, or treat the existing content as empty.
 
-            3. Prepend a new entry at the top of the file in this exact format:
-                 ## ${{ github.event.release.tag_name }} — YYYY-MM-DD
+            3. If CHANGELOG.md already has an entry for ${{ github.event.inputs.tag_name }}, replace
+               that entry with the enriched release body. Otherwise, prepend a new entry at the top
+               of the file in this exact format:
+                 ## ${{ github.event.inputs.tag_name }} — YYYY-MM-DD
                  <release body text>
 
-               Use ${{ github.event.release.published_at }} for the date; format it as YYYY-MM-DD.
+               Use the release's publishedAt for the date; format it as YYYY-MM-DD.
                If the file already has content, leave a blank line between the new entry and the existing content.
 
             4. Write the updated (or newly created) CHANGELOG.md.
@@ -46,6 +55,6 @@ jobs:
                  git config user.name "github-actions[bot]"
                  git config user.email "github-actions[bot]@users.noreply.github.com"
                  git add CHANGELOG.md
-                 git commit -m "chore: update changelog for ${{ github.event.release.tag_name }}"
+                 git commit -m "chore: update changelog for ${{ github.event.inputs.tag_name }}"
                  git pull --rebase origin main
                  git push origin main


### PR DESCRIPTION
## Summary

Fixes the sequencing bug where `vX.Y.Z` pointed to a commit without its own `CHANGELOG.md` entry.

### Changes

**`auto-tag.yml`**
- Adds an early-exit guard: if the triggering commit message matches `^chore: update changelog`, the job exits immediately — preventing recursive re-triggering when the workflow pushes the changelog commit back to `main`.
- Before creating the tag, generates a basic `CHANGELOG.md` entry from `git log` (excluding automated changelog commits) and commits it to `main`.
- Uses `GH_WORKFLOW_TOKEN` for checkout so the git push of the changelog commit is authorized.
- Creates the tag (`git tag`) **after** the changelog commit is on `main`, so the tag always points to a commit that includes the changelog entry.

**`changelog.yml`**
- Changes trigger from `release: [published]` to `workflow_dispatch` with a `tag_name` input.
- This prevents the double-update race (auto-tag writes basic changelog → release triggers Claude to overwrite it) while keeping Claude-powered changelog enrichment available for manual runs.
- Updates the prompt to use `inputs.tag_name` and to replace an existing entry for that tag if one is already present.

### New sequence
1. PR merges → push to `main` triggers `auto-tag.yml`
2. `auto-tag.yml` generates changelog entry, commits it to `main`
3. `auto-tag.yml` creates tag on the changelog commit → tag always contains the entry
4. `auto-tag.yml` creates GitHub release
5. (Optional) Run `changelog.yml` manually to enrich the entry with Claude-generated release notes

Closes #91

Generated with [Claude Code](https://claude.ai/code)
