### PR TITLE
fix: add Bash(date:*) to allowedTools in claude-proactive.yml

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

Add Bash(date:*) to the allowedTools list in .github/workflows/claude-proactive.yml so Claude can compute PR age using date commands.

Without this, the Pass 1 stale-PR health check (PRs open > 2 days without a review decision) cannot reliably determine PR age from the createdAt ISO timestamp.

Closes #102

Generated with [Claude Code](https://claude.ai/code)