### PR TITLE
fix: add Closes #<N> compliance check to code review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,17 +31,31 @@ jobs:
             1. Correctness and logic errors
             2. Security vulnerabilities
             3. Breaking changes
+            4. CLAUDE.md compliance: the PR body must include a GitHub closing keyword with issue number
+
+            ## Step 1: Check CLAUDE.md compliance
+
+            Fetch the PR body and verify it contains a closing keyword:
+              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq '.body'
+
+            The body MUST match the pattern (case-insensitive): `(closes|fixes|resolves) #[0-9]+`
+            If this pattern is absent, it is a BLOCKING issue. Note it as:
+            "PR body must include `Closes #<issue-number>` per CLAUDE.md. Please add it."
+
+            ## Step 2: Review code
 
             Post review comments inline on the diff using the GitHub API.
             Be concise. Focus on significant issues only.
             # CUSTOMIZE: Add stack-specific review criteria here
 
-            After posting inline comments, submit a formal review decision using the GitHub API.
-            Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).
-            If no blocking issues:
+            ## Step 3: Submit review decision
+
+            Submit a formal review using the GitHub API.
+            A blocking issue is any of: significant bugs, security vulnerabilities, breaking changes, or missing close keyword in PR body.
+            If no blocking issues (code is fine AND PR body contains a close keyword):
               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
-            If blocking issues found:
+            If blocking issues found (including missing Closes/Fixes/Resolves #N link):
               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
-            Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, or breaking changes. Use APPROVE for minor issues, style comments, or suggestions.
+            Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, breaking changes, or missing Closes/Fixes/Resolves #N link. Use APPROVE for minor issues, style comments, or suggestions.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"


### PR DESCRIPTION
## Summary

Add a CLAUDE.md compliance check to the review prompt in `.github/workflows/claude-code-review.yml` so the reviewer blocks PRs that are missing a GitHub close keyword (`Closes #N`, `Fixes #N`, or `Resolves #N`) in their body.

### Changes

- Added a **Step 1** to the review prompt that fetches the PR body via `gh pr view ... --json body` and checks for the required closing-keyword pattern
- A missing close keyword is now treated as a **blocking issue**, causing the reviewer to REQUEST_CHANGES with the message: `PR body must include `Closes #<issue-number>` per CLAUDE.md. Please add it.`
- Restructured the prompt into three numbered steps (compliance check → code review → submit decision) for clarity
- YAML validated ✓

### Why

Without this check, Claude can create PRs without `Closes #N`, the reviewer approves them, the shepherd merges, but the originating issue stays open forever because the `claude-task` label exempts it from stale closure. This fix closes that gap.

Closes #103

Generated with [Claude Code](https://claude.ai/code)