### PR TITLE
fix: handle git pull --rebase failure in auto-tag with fallback and notification

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   auto-tag:
@@ -88,13 +89,35 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "chore: update changelog for ${NEW_TAG}"
-          git pull --rebase origin main
-          git push origin main
 
-          # Tag now points to the commit that includes the updated changelog
+          # Try to sync with origin/main and push the changelog commit.
+          # If a concurrent push caused a conflict, fall back to tagging HEAD
+          # without the changelog commit and file a notification issue.
+          CHANGELOG_PUSHED=true
+          if git pull --rebase origin main; then
+            git push origin main
+          else
+            echo "::warning::git pull --rebase failed; aborting and tagging HEAD without changelog update"
+            git rebase --abort 2>/dev/null || true
+            # Undo the changelog commit so we tag the original HEAD
+            git reset --hard HEAD~1
+            CHANGELOG_PUSHED=false
+          fi
+
+          # Tag the current HEAD (includes changelog commit if push succeeded)
           git tag $NEW_TAG
           git push origin $NEW_TAG
           echo "Tagged: $NEW_TAG"
           gh release create "$NEW_TAG" \
             --generate-notes \
             --title "$NEW_TAG"
+
+          # Notify if changelog was skipped so a human can update it manually
+          if [ "$CHANGELOG_PUSHED" = "false" ]; then
+            ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because `git pull --rebase origin main` failed (a concurrent push likely landed on `main` during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s' \
+              "$NEW_TAG" "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}")
+            gh issue create \
+              --title "Changelog skipped for ${NEW_TAG}: rebase conflict on main" \
+              --body "$ISSUE_BODY" \
+              || echo "::warning::Failed to create notification issue"
+          fi


### PR DESCRIPTION
## Summary

- Wraps the `git pull --rebase origin main` call in error handling so a rebase conflict no longer silently drops the release
- On failure: aborts the rebase, resets the local changelog commit, and continues to tag + release the original HEAD
- After a successful tag+release with the fallback active, files a GitHub issue notifying maintainers that the changelog was skipped and needs a manual update
- Adds `issues: write` permission to the workflow to support issue creation

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Rebase succeeds | Tag + changelog commit pushed | Same |
| Rebase fails | Workflow fails, no tag, no release, no notification | Tag + release created from HEAD; GitHub issue filed |

Closes #101

Generated with [Claude Code](https://claude.ai/code)