### PR TITLE
fix: add updatedAt to pr list and gate stuck-shepherd on 2h threshold

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -50,11 +50,13 @@ jobs:
             - CLAUDE.md instructions that are unclear or missing
 
             Also check the real-world health of the factory loop by running:
-              gh pr list --repo ${{ github.repository }} --state open --json number,title,createdAt,reviewDecision
+              gh pr list --repo ${{ github.repository }} --state open --json number,title,createdAt,updatedAt,reviewDecision
             Flag and file an issue for each of the following (if no open issue already covers it):
             - Any PR that has been open > 2 days without a review decision (scanner is blind or
               the review workflow is broken)
-            - Any PR whose reviewDecision is APPROVED but has not been merged (shepherd may be stuck)
+            - Any PR whose reviewDecision is APPROVED but has not been merged AND whose updatedAt
+              is more than 2 hours ago (7200 seconds before current time); skip recently-approved
+              PRs to avoid false positives while the shepherd completes its next cycle
 
             **Pass 2 — General codebase issues**:
             - Logic errors, race conditions, unhandled exceptions


### PR DESCRIPTION
## Summary

- Adds `updatedAt` to the `gh pr list` JSON fields in `claude-proactive.yml`
- Updates the prompt to only flag APPROVED-but-not-merged PRs where `updatedAt` is more than 2 hours ago (7200 seconds), matching the 2-hour threshold used elsewhere in the factory
- Prevents false-positive stuck-shepherd issues when a PR was just approved but the shepherd has not yet had its next cycle

## Changes

**File:** `.github/workflows/claude-proactive.yml`

Before:
```
gh pr list --repo ... --json number,title,createdAt,reviewDecision
- Any PR whose reviewDecision is APPROVED but has not been merged (shepherd may be stuck)
```

After:
```
gh pr list --repo ... --json number,title,createdAt,updatedAt,reviewDecision
- Any PR whose reviewDecision is APPROVED but has not been merged AND whose updatedAt
  is more than 2 hours ago (7200 seconds before current time); skip recently-approved
  PRs to avoid false positives while the shepherd completes its next cycle
```

Closes #109

Generated with [Claude Code](https://claude.ai/code)