### PR TITLE
fix: add claude-task label guard to merge step in pr-shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -63,7 +63,8 @@ jobs:
                - If mergeable is null: GitHub has not yet computed mergeability — skip this PR silently and wait for the next shepherd run — do not post a comment.
                - If CI is not passing: skip (step 1 handles notifications).
                - If reviewDecision is not APPROVED: skip (steps 5–6 handle notifications).
-               If all pre-checks pass (mergeable is true, CI passes, reviewDecision is APPROVED), merge:
+               - If none of the label objects in the labels array has name equal to "claude-task": skip to the next PR — do not merge, do not comment.
+               If all pre-checks pass (mergeable is true, CI passes, reviewDecision is APPROVED, and PR has the claude-task label), merge:
                Run the merge command, capturing both output and exit code:
                  merge_output=$(gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch 2>&1); merge_exit=$?
                If merge_exit is non-zero (the merge command failed):


### PR DESCRIPTION
## Summary

Adds a `claude-task` label guard to the merge step (step 4) in `claude-pr-shepherd.yml`.

Previously, the shepherd would auto-merge **any** PR that was APPROVED, CI-passing, and mergeable — regardless of whether it had the `claude-task` label. This meant human-authored PRs could be automatically merged within 15 minutes of receiving an approval.

The fix adds a pre-check in step 4: if none of the label objects in the PR's labels array has name equal to `claude-task`, the shepherd skips to the next PR without merging or commenting. This mirrors the existing label guard already present for steps 5 and 6.

### Change

`.github/workflows/claude-pr-shepherd.yml`, step 4 pre-checks — added:
```
- If none of the label objects in the labels array has name equal to "claude-task": skip to the next PR — do not merge, do not comment.
```

Closes #124

Generated with [Claude Code](https://claude.ai/code)