### PR TITLE
fix: include Closes #N reminder in auto-assign trigger comment

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -54,7 +54,7 @@ jobs:
 
           if [ "$AUTHORIZED" = "true" ]; then
             gh issue comment $ISSUE_NUMBER --repo $REPO \
-              --body "@claude please implement this issue"
+              --body "@claude please implement issue #${ISSUE_NUMBER}. When you create a PR, include Closes #${ISSUE_NUMBER} in the PR body so the issue auto-closes on merge."
 
             # Ensure the claude-task label exists, then apply it so stale.yml
             # won't auto-close factory-assigned issues before Claude implements them


### PR DESCRIPTION
## Summary

Update the trigger comment body in `claude-auto-assign.yml` to include a reminder for Claude to add `Closes #ISSUE_NUMBER` in the PR body when implementing issues.

**Before:**
```
@claude please implement this issue
```

**After:**
```
@claude please implement issue #N. When you create a PR, include Closes #N in the PR body so the issue auto-closes on merge.
```

This is defence-in-depth for the CLAUDE.md convention requiring `Closes #N` in all PR bodies. Issue #103 catches missing links at review time; this fix adds it earlier at the trigger point.

Closes #125

Generated with [Claude Code](https://claude.ai/code)