### PR TITLE
fix: add GH_WORKFLOW_TOKEN to changelog.yml checkout step

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.GH_WORKFLOW_TOKEN }}
 
       - name: Update CHANGELOG.md
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

Add token to the actions/checkout@v4 step in changelog.yml.

Without this token, the checkout configures the git remote with the default GITHUB_TOKEN, which cannot push to main when branch protection rules require a PAT or higher-privilege token. The Claude prompt inside the job calls git push origin main, which then fails.

This matches the existing pattern in auto-tag.yml line 21, which already uses GH_WORKFLOW_TOKEN for the same reason.

Closes #130

Generated with [Claude Code](https://claude.ai/code)
