### PR TITLE
fix: remove ambiguous label guard note from shepherd prompt

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -78,7 +78,6 @@ jobs:
                  Otherwise (no such comment exists, OR the comment predates the latest commit), post a comment and skip to the next PR:
                    printf '@claude the automated merge failed with:\n%s\nPlease investigate and push a fix or manually merge.' "${merge_output}" > /tmp/merge_error_body.txt
                    gh pr comment <number> --repo ${{ github.repository }} --body-file /tmp/merge_error_body.txt
-            Label guard (applies to steps 5 and 6 only): The labels field from the PR list is an array of objects, each with a "name" field. If none of the label objects has name equal to "claude-task", skip steps 5 and 6 and move to the next PR.
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
             6. If reviewDecision is null or REVIEW_REQUIRED:


### PR DESCRIPTION
## Summary

Remove the standalone 'Label guard (applies to steps 5 and 6 only)' paragraph from the shepherd prompt to eliminate the contradiction with the label check already in step 4's pre-checks.

**Problem:** The phrase 'applies to steps 5 and 6 only' could cause Claude to interpret the `claude-task` label as not required for the merge step in step 4 — only for the notification steps (5 and 6). This could allow unlabeled PRs to be auto-merged.

**Fix:** Delete the redundant "Label guard" paragraph. Step 4's pre-check already includes:
> If none of the label objects in the labels array has name equal to "claude-task": skip to the next PR — do not merge, do not comment.

The "skip to the next PR" instruction naturally prevents steps 5 and 6 from executing as well, making the separate label guard paragraph both redundant and misleading.

Closes #131

Generated with [Claude Code](https://claude.ai/code)
