### PR TITLE
fix: add Bash(date:*) to allowedTools in claude-self-improve.yml

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory conducting its weekly deep self-improvement scan.
             This repo IS the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

Add `Bash(date:*)` to the `allowedTools` list in `claude-self-improve.yml` to match `claude-proactive.yml`.

Without this tool permission, the weekly deep scanner's Pass 1 (stuck-PR detection) cannot compute PR ages using `date -d "<timestamp>" +%s`, causing stuck-PR detection to silently fail.

**Before:**
```
Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Read,Glob,Grep
```

**After:**
```
Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(date:*),Read,Glob,Grep
```

Closes #139

Generated with [Claude Code](https://claude.ai/code)