### PR TITLE
fix: add dedup check before creating Changelog skipped issues

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -168,8 +168,13 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            gh issue create \
-              --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \
-              --body "$ISSUE_BODY" \
-              || echo "::warning::Failed to create notification issue"
+            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --search "Changelog skipped" --json number --jq length)
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "Open 'Changelog skipped' issue already exists; skipping duplicate creation"
+            else
+              gh issue create \
+                --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \
+                --body "$ISSUE_BODY" \
+                || echo "::warning::Failed to create notification issue"
+            fi
           fi


### PR DESCRIPTION
## Summary

Before creating a Changelog skipped notification issue, check whether an open issue matching 'Changelog skipped' already exists. If one is found, skip creating a duplicate. This prevents the unbounded backlog accumulation seen in issues #113, #136, and #137.

## Changes

- .github/workflows/auto-tag.yml: Added gh issue list --search 'Changelog skipped' dedup guard before gh issue create in the changelog-skipped notification block (lines 168-175).

## How it works

Added EXISTING check using gh issue list with --search flag. If any open issue matching 'Changelog skipped' exists, the workflow logs a message and skips creating a duplicate. Otherwise, it proceeds with gh issue create as before.

Closes #138

Generated with [Claude Code](https://claude.ai/code)