### PR TITLE
fix: replace --search with REST list API for dedup guard in auto-tag.yml

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -168,7 +168,7 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --search "Changelog skipped" --json number --jq length)
+            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title --jq '[.[] | select(.title | startswith("Changelog skipped"))] | length')
             if [ "$EXISTING" -gt 0 ]; then
               echo "Open 'Changelog skipped' issue already exists; skipping duplicate creation"
             else


### PR DESCRIPTION
## Summary

Replace the GitHub full-text `--search` flag with the REST list endpoint + local `jq` filter in the `CHANGELOG_PUSHED=false` dedup guard of `auto-tag.yml`.

The REST list endpoint has no search indexing lag, making the dedup reliable even during concurrent runs. This prevents duplicate 'Changelog skipped' issues like #113, #136, and #137 from being created when multiple auto-tag runs happen in rapid succession.

## Change

Before: `gh issue list --repo "$REPOSITORY" --state open --search "Changelog skipped" --json number --jq length`

After: `gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title --jq '[.[] | select(.title | startswith("Changelog skipped"))] | length'`

Closes #142

Generated with [Claude Code](https://claude.ai/code)