### PR TITLE
fix: add Bash(gh run view:*) to allowedTools in claude-self-improve.yml

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory conducting its weekly deep self-improvement scan.
             This repo IS the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

Add `Bash(gh run view:*)` to the `allowedTools` list in `claude-self-improve.yml` so the weekly deep scanner can inspect individual workflow run details during Pass 4.

Previously, Pass 4 could identify workflows with high failure rates via `gh run list`, but could not drill into the specific failed steps or logs to determine root causes (e.g., permission errors, missing secrets, broken action steps).

With `gh run view` allowed, the scanner can call `gh run view <run-id> --log-failed` to retrieve step-level failure details and file more actionable improvement issues.

## Change

- **File:** `.github/workflows/claude-self-improve.yml`, line 28
- **Added:** `Bash(gh run view:*)` to the `claude_args` allowedTools list

Closes #147

Generated with [Claude Code](https://claude.ai/code)