### PR TITLE
fix: scope changelog-skipped dedup guard to specific version tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -168,9 +168,9 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title --jq '[.[] | select(.title | startswith("Changelog skipped"))] | length')
+            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title | jq --arg tag "$NEW_TAG" '[.[] | select(.title | contains($tag))] | length')
             if [ "$EXISTING" -gt 0 ]; then
-              echo "Open 'Changelog skipped' issue already exists; skipping duplicate creation"
+              echo "Open 'Changelog skipped' issue for ${NEW_TAG} already exists; skipping duplicate creation"
             else
               gh issue create \
                 --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \


### PR DESCRIPTION
## Summary

- **Bug**: auto-tag.yml line 171 used startswith("Changelog skipped") in its jq filter, meaning any open Changelog skipped issue (for any version) would suppress new notifications for different versions.
- **Fix**: Changed the jq filter to pipe gh issue list JSON output to jq --arg tag "$NEW_TAG" with contains($tag), so dedup is scoped to the exact version tag. Each version now gets its own notification issue; only true duplicates (same version) are suppressed.

Closes #145

Generated with [Claude Code](https://claude.ai/code)