### PR TITLE
fix: check approval timestamp before merging to prevent stale-approval merges

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -64,7 +64,14 @@ jobs:
                - If CI is not passing: skip (step 1 handles notifications).
                - If reviewDecision is not APPROVED: skip (steps 5–6 handle notifications).
                - If none of the label objects in the labels array has name equal to "claude-task": skip to the next PR — do not merge, do not comment.
-               If all pre-checks pass (mergeable is true, CI passes, reviewDecision is APPROVED, and PR has the claude-task label), merge:
+               - Stale approval check: verify that the most recent APPROVED review was submitted after the latest commit (prevents merging unreviewed code when a new commit was pushed after the approval).
+                 Get the most recent APPROVED review timestamp:
+                   Run: gh api repos/${{ github.repository }}/pulls/<number>/reviews --jq '[.[] | select(.state=="APPROVED")] | max_by(.submitted_at) | .submitted_at'
+                   (Returns an ISO 8601 timestamp string, or empty/null if no APPROVED review exists)
+                 Get the most recent commit timestamp:
+                   Run: gh pr view <number> --repo ${{ github.repository }} --json commits --jq '.commits[-1].committedDate'
+                 Compare the two timestamps as strings (ISO 8601 UTC strings sort correctly lexicographically). If the approval timestamp is less than the commit timestamp, the approval predates the latest commit — skip this PR silently (a new review run should be in flight or will be triggered by step 6). Do not post a comment.
+               If all pre-checks pass (mergeable is true, CI passes, reviewDecision is APPROVED, approval is not stale, and PR has the claude-task label), merge:
                Run the merge command, capturing both output and exit code:
                  merge_output=$(gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch 2>&1); merge_exit=$?
                If merge_exit is non-zero (the merge command failed):


### PR DESCRIPTION
## Summary

- Adds a **stale approval check** as the final pre-merge guard in step 4 of `claude-pr-shepherd.yml`
- Before merging, the shepherd now fetches the most recent APPROVED review timestamp and the latest commit timestamp
- If the approval predates the latest commit, the PR is skipped silently — a new review run should be in flight or will be triggered by step 6
- Uses lexicographic ISO 8601 UTC string comparison (which is semantically correct for UTC timestamps)

## Problem Solved

Without this fix, there was a merge-without-review window:
1. Commit A gets APPROVED by `claude-code-review.yml`
2. Commit B is pushed; the new review run is cancelled (via `cancel-in-progress: true`) or fails
3. The PR retains the stale APPROVED status from commit A
4. On the next shepherd cycle, CI passes for commit B and `reviewDecision` is still APPROVED → shepherd merges unreviewed code

## Changes

`.github/workflows/claude-pr-shepherd.yml` — Added stale approval check in step 4 pre-merge checks using:
- `gh api repos/OWNER/REPO/pulls/NUMBER/reviews` to fetch the latest APPROVED review timestamp
- `gh pr view NUMBER --json commits` to fetch the latest commit timestamp
- Skip silently if approval predates the commit

Closes #146

Generated with [Claude Code](https://claude.ai/code)