### PR TITLE
fix: add Bash(gh run view:*) to allowedTools in claude-proactive.yml

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
Add Bash(gh run view:*) to the claude_args allowed tools list in .github/workflows/claude-proactive.yml to match the set already present in claude-self-improve.yml (added in commit 8e984d6). Without this tool, the hourly proactive scanner cannot inspect specific workflow run details when identifying broken shepherds or failing workflows, limiting the quality of issues it can file. Closes #154 Generated with Claude Code https://claude.ai/code