### PR TITLE
fix: add claude-task label to auto-tag notification issues

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -148,6 +148,10 @@ jobs:
           git tag $NEW_TAG
           git push origin $NEW_TAG
           echo "Tagged: $NEW_TAG"
+
+          # Ensure claude-task label exists so notification issues aren't auto-closed by stale bot
+          gh label create claude-task --description 'Assigned to Claude for implementation' --color 7057ff 2>/dev/null || true
+
           if gh release create "$NEW_TAG" \
             --generate-notes \
             --title "$NEW_TAG"; then
@@ -161,6 +165,7 @@ jobs:
             gh issue create \
               --title "Release missing for ${NEW_TAG}: gh release create failed" \
               --body "$RELEASE_BODY" \
+              --label claude-task \
               || echo "::warning::Failed to create notification issue for missing release"
           fi
 
@@ -175,6 +180,7 @@ jobs:
               gh issue create \
                 --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \
                 --body "$ISSUE_BODY" \
+                --label claude-task \
                 || echo "::warning::Failed to create notification issue"
             fi
           fi


### PR DESCRIPTION
## Summary

- Adds `gh label create claude-task ... 2>/dev/null || true` before the release creation block so the label is guaranteed to exist
- Adds `--label claude-task` to both `gh issue create` calls in `auto-tag.yml`:
  - "Release missing" notification issues (previously line 161)
  - "Changelog skipped" notification issues (previously line 175)

Without this fix, the stale bot would mark these notification issues stale after 14 days and auto-close them after 21 days — before Claude can act on them. Four existing Changelog-skipped issues (#113, #136, #137, #151) were already at risk.

Closes #152

Generated with [Claude Code](https://claude.ai/code)