### PR TITLE
fix: add Bash(gh workflow run:*) to shepherd and workflow_dispatch to code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,12 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,13 +18,13 @@ permissions:
   actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     steps:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
@@ -39,9 +45,9 @@ jobs:
             After posting inline comments, submit a formal review decision using the GitHub API.
             Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).
             If no blocking issues:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
             If blocking issues found:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
             Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, or breaking changes. Use APPROVE for minor issues, style comments, or suggestions.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"

--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh issue:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh workflow run:*),Bash(gh api:*),Bash(gh issue:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
           prompt: |
             You are a PR shepherd for the repo ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary

- Add `Bash(gh workflow run:*)` to `allowedTools` in `claude-pr-shepherd.yml` so the shepherd can directly dispatch `claude-code-review.yml` instead of posting `@claude` comments (prerequisite for #80)
- Add `workflow_dispatch` trigger with `pr_number` input to `claude-code-review.yml` so the shepherd can target a specific PR for review
- Update concurrency group and job condition to handle both `pull_request` and `workflow_dispatch` events

## Changes

### `claude-pr-shepherd.yml`
Added `Bash(gh workflow run:*)` to the `claude_args` allowed tools list, enabling the shepherd to call `gh workflow run claude-code-review.yml --repo OWNER/REPO --field pr_number=N`

### `claude-code-review.yml`
Added `workflow_dispatch` trigger with `pr_number` input. Updated concurrency group and `if` condition to handle both trigger types, and updated PR number references to use `inputs.pr_number` as fallback when dispatched manually.

Closes #153

Generated with [Claude Code](https://claude.ai/code)
