### PR TITLE
feat: add Bash(gh run view:*) and Bash(gh run list:*) to allowedTools in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,5 +39,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
           # CUSTOMIZE: Add your stack's build/lint/test commands to the allowedTools list above


### PR DESCRIPTION
## Summary

Add `Bash(gh run view:*)` and `Bash(gh run list:*)` to the `allowedTools` list in `.github/workflows/claude.yml` so Claude can diagnose CI failures accurately.

This mirrors the tools already present in `claude-proactive.yml` (added in commit 8a735e2).

**Change:** Added two tools after `Bash(gh pr checks:*)` in the `claude_args` allowedTools string on line 42.

With these tools Claude can:
1. List recent workflow runs: `gh run list --repo REPO --limit 10`
2. View full run logs for a failing check: `gh run view RUN_ID --repo REPO --log-failed`

This enables accurate root-cause analysis of CI failures without multiple guess-and-push iterations.

Closes #160

Generated with [Claude Code](https://claude.ai/code)