### PR TITLE
fix: add idempotency guard to auto-tag.yml to prevent spurious 'Release missing' issues

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -144,6 +144,14 @@ jobs:
             CHANGELOG_PUSHED=false
           fi
 
+          # Idempotency guard: exit cleanly if a concurrent run already pushed this tag.
+          # This prevents spurious 'Release missing' issues when two runs race to create
+          # the same tag (e.g. during rapid merges before a concurrency group is in place).
+          if git ls-remote --tags origin "$NEW_TAG" | grep -q "$NEW_TAG"; then
+            echo "Tag $NEW_TAG already exists on origin (concurrent run beat us) — exiting cleanly"
+            exit 0
+          fi
+
           # Tag the current HEAD (includes changelog commit if push succeeded)
           git tag $NEW_TAG
           git push origin $NEW_TAG


### PR DESCRIPTION
## Summary

Adds an idempotency guard before the tag push in `auto-tag.yml` to handle concurrent runs gracefully.

### Problem

When two runs race to create the same tag (e.g. rapid merges before a concurrency group):
1. Run A succeeds: pushes changelog commit, creates tag, creates GitHub release
2. Run B: changelog push fails, resets to original HEAD, then `git push origin vX.Y.Z` silently fails (tag exists), continues to `gh release create` which fails with 'release already exists', and incorrectly files a 'Release missing' issue

### Fix

Before attempting to push the tag, check if it already exists on the remote:

```bash
if git ls-remote --tags origin "$NEW_TAG" | grep -q "$NEW_TAG"; then
  echo "Tag $NEW_TAG already exists on origin (concurrent run beat us) — exiting cleanly"
  exit 0
fi
```

This exits cleanly if a concurrent run already created the tag and release, providing defense-in-depth alongside any concurrency group (issue #16).

### Changes

- `.github/workflows/auto-tag.yml`: Added 8-line idempotency guard (with explanatory comment) before `git tag $NEW_TAG` / `git push origin $NEW_TAG` at ~line 147

Closes #161

Generated with [Claude Code](https://claude.ai/code)