### PR TITLE
fix: add --limit 100 to gh pr list in claude-pr-shepherd.yml

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -31,7 +31,7 @@ jobs:
             You are a PR shepherd for the repo ${{ github.repository }}.
 
             List all open, non-draft PRs:
-              gh pr list --repo ${{ github.repository }} --state open --json number,title,isDraft,mergeable,labels
+              gh pr list --repo ${{ github.repository }} --state open --limit 100 --json number,title,isDraft,mergeable,labels
 
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

Add `--limit 100` to the `gh pr list` command in `claude-pr-shepherd.yml` so the shepherd processes all open PRs rather than being silently capped at the gh CLI default of 30 items.

Without this flag, any repository with more than 30 open PRs would have those extra PRs silently ignored — they would never be merged, notified of CI failures, or requested for review.

## Change

```diff
-  gh pr list --repo ... --state open --json number,title,isDraft,mergeable,labels
+  gh pr list --repo ... --state open --limit 100 --json number,title,isDraft,mergeable,labels
```

Closes #168

Generated with [Claude Code](https://claude.ai/code)