### PR TITLE
fix: use atomic review API to prevent orphaned inline comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,17 +31,48 @@ jobs:
             1. Correctness and logic errors
             2. Security vulnerabilities
             3. Breaking changes
-
-            Post review comments inline on the diff using the GitHub API.
-            Be concise. Focus on significant issues only.
             # CUSTOMIZE: Add stack-specific review criteria here
 
-            After posting inline comments, submit a formal review decision using the GitHub API.
-            Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).
-            If no blocking issues:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
-            If blocking issues found:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
-            Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, or breaking changes. Use APPROVE for minor issues, style comments, or suggestions.
+            ## Review Process (follow these steps in order)
+
+            **Step 1 – Fetch the diff:**
+            Retrieve changed files and diff hunks using:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+
+            **Step 2 – Analyse completely, collect findings internally:**
+            Review every changed file. Note each issue with its file path and line number.
+            Do NOT make any GitHub API calls at this stage.
+
+            **Step 3 – Submit a single atomic review:**
+            Post exactly one call to the reviews API that embeds both the review decision and all
+            inline comments in the same request. This is critical: posting comments atomically with
+            the review decision ensures no orphaned comments are left if the job is cancelled.
+
+            Build a JSON payload and submit it via:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+                --method POST --input review.json
+
+            The JSON payload must have this shape:
+              {
+                "body": "<overall review summary>",
+                "event": "<APPROVE or REQUEST_CHANGES>",
+                "comments": [
+                  {
+                    "path": "<file path relative to repo root>",
+                    "line": <line number in the file>,
+                    "side": "RIGHT",
+                    "body": "<comment text>"
+                  }
+                ]
+              }
+
+            For added or changed lines use side "RIGHT"; for removed lines use side "LEFT".
+            Omit the "comments" key entirely when there are no inline comments.
+
+            Determine the event value:
+            - Use APPROVE when no blocking issues exist (minor issues, style, and suggestions → APPROVE).
+            - Use REQUEST_CHANGES only for significant bugs, security vulnerabilities, or breaking changes.
+
+            Be concise. Focus on significant issues only.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"


### PR DESCRIPTION
## Summary

Updates the review prompt in `claude-code-review.yml` to eliminate the race condition where a cancelled job could leave orphaned inline PR comments with no associated review decision.

### Changes

- **Removed** the two-step flow: post inline comments → submit review decision
- **Added** a three-step flow:
  1. Fetch the PR diff via `gh api .../pulls/{n}/files`
  2. Collect all findings internally (no API calls)
  3. Submit a **single atomic** `POST /reviews` request with inline comments embedded in the `comments` array and the `event` field in the same payload

This matches the behaviour described in the [GitHub PR Reviews API](https://docs.github.com/en/rest/pulls/reviews), which guarantees that comments and the review decision are either all published or none are — preventing orphaned comments when the job is cancelled mid-run due to `cancel-in-progress: true`.

Closes #167

Generated with [Claude Code](https://claude.ai/code)