### PR TITLE
feat: add health check for claude-code-review.yml in proactive scanner

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -62,8 +62,23 @@ jobs:
               failing — investigate broken shepherd") instead of per-PR stuck issues.
             - Do NOT file per-PR stuck issues when the shepherd is globally broken; those would
               only add noise while the root cause is the broken shepherd.
-            If at least one recent shepherd run succeeded, the shepherd is healthy. In that case,
-            check stuck PRs by running:
+
+            Next, check code review workflow health:
+              gh run list --workflow=claude-code-review.yml --limit 5 --json conclusion,startedAt
+            If the command returns an empty array (no results), the code review workflow has no run
+            history — treat it as healthy and proceed directly to per-PR stuck logic below.
+            If every one of the 5 most recent code review runs has conclusion "failure" or "cancelled"
+            (i.e. no successful run exists), the code review workflow itself is broken. In that case:
+            - Before filing, check for an existing code review health issue:
+                gh issue list --state open --search "claude-code-review" --limit 10
+              Only file ONE issue if no matching open issue already exists.
+            - File ONE issue about code review health (e.g. "claude-code-review.yml: all recent runs
+              failing — investigate broken reviewer") instead of per-PR stuck issues.
+            - Do NOT file per-PR stuck issues when the reviewer is globally broken; those would
+              only add noise while the root cause is the broken reviewer.
+
+            If at least one recent shepherd run succeeded AND at least one recent code review run
+            succeeded (both are healthy), check stuck PRs by running:
               gh pr list --repo ${{ github.repository }} --state open --json number,title,createdAt,updatedAt,reviewDecision
             Flag and file an issue for each of the following (if no open issue already covers it):
             - Any PR that has been open > 2 days without a review decision (scanner is blind or


### PR DESCRIPTION
## Summary

Adds a symmetric health check for `claude-code-review.yml` in Pass 1 of `claude-proactive.yml`, mirroring the existing shepherd health check.

### Changes

- Added new health check block that runs `gh run list --workflow=claude-code-review.yml --limit 5` after the shepherd check
- If all 5 most recent code review runs have `failure` or `cancelled` conclusion:
  - Checks for an existing code review health issue before filing (using `--search 'claude-code-review'`)
  - Files ONE issue: `claude-code-review.yml: all recent runs failing — investigate broken reviewer`
  - Skips per-PR stuck issues (they are symptoms, not root causes)
- Per-PR stuck checks now only run when **both** shepherd and code review workflows are healthy
- Empty run history is treated as healthy (consistent with shepherd behavior)

### Why

A broken code review workflow silently stalls the factory loop — PRs accumulate without review decisions, but the scanner only detects this via per-PR stuck logic after 2+ days. This change detects the root cause within 1 hour of systematic failure, preventing floods of individual stuck-PR issues.

Closes #172

Generated with [Claude Code](https://claude.ai/code)