### PR TITLE
fix: add Bash(gh release:*) to claude.yml allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,5 +39,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh issue:*),Bash(gh release:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
           # CUSTOMIZE: Add your stack's build/lint/test commands to the allowedTools list above


### PR DESCRIPTION
## Summary

Add `Bash(gh release:*)` to the `allowedTools` list in `claude.yml` so Claude can create and manage GitHub releases when handling "Release missing" notification issues generated by `auto-tag.yml`.

Without this permission, Claude receives the task but cannot execute `gh release create`, making those notification issues unresolvable.

## Changes

- `.github/workflows/claude.yml` line 42: appended `Bash(gh release:*)` after `Bash(gh issue:*)` in the `--allowedTools` string

Closes #173

Generated with [Claude Code](https://claude.ai/code)