### PR TITLE
fix: add authorization gate for pull_request_review trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,10 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        (github.event.review.user.login == 'greynewell' ||
+         github.event.review.user.login == 'github-actions[bot]' ||
+         github.event.review.user.login == 'claude[bot]')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The `pull_request_review: submitted` trigger in `claude.yml` had no authorization check — any GitHub user could invoke the write-capable Claude agent by submitting a PR review with `@claude` in the body.

### Change

Extended the job-level `if:` condition for the `pull_request_review` event to also verify `github.event.review.user.login` is in the allowed list, matching the authorization pattern from `claude-auto-assign.yml`:

```yaml
(github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
  (github.event.review.user.login == 'greynewell' ||
   github.event.review.user.login == 'github-actions[bot]' ||
   github.event.review.user.login == 'claude[bot]')) ||
```

Unauthorized PR review submissions mentioning `@claude` will now be silently skipped by the workflow condition before any agent runs.

Closes #174

Generated with [Claude Code](https://claude.ai/code)