### PR TITLE
fix: add author whitelist to issue_comment and pull_request_review_comment triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,8 +25,14 @@ jobs:
   claude:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.user.login == 'greynewell' ||
+         github.event.comment.user.login == 'github-actions[bot]' ||
+         github.event.comment.user.login == 'claude[bot]')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.user.login == 'greynewell' ||
+         github.event.comment.user.login == 'github-actions[bot]' ||
+         github.event.comment.user.login == 'claude[bot]')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
         (github.event.review.user.login == 'greynewell' ||
          github.event.review.user.login == 'github-actions[bot]' ||


### PR DESCRIPTION
## Summary

Adds author whitelist checks to the `issue_comment` and `pull_request_review_comment` triggers in `claude.yml`, restricting them to authorized users (`greynewell`, `github-actions[bot]`, `claude[bot]`).

### Changes

- `issue_comment`: Added `github.event.comment.user.login` check consistent with the existing `pull_request_review` guard
- `pull_request_review_comment`: Added the same `github.event.comment.user.login` check

### Before
Any authenticated GitHub user could trigger Claude by commenting `@claude` on any public issue or PR.

### After
Only `greynewell`, `github-actions[bot]`, and `claude[bot]` can trigger Claude via comments, matching the existing guard on `pull_request_review`.

Closes #180

Generated with [Claude Code](https://claude.ai/code)