### PR TITLE
feat: add workflow_dispatch trigger to claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,12 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,13 +18,13 @@ permissions:
   actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     steps:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
@@ -39,9 +45,9 @@ jobs:
             After posting inline comments, submit a formal review decision using the GitHub API.
             Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).
             If no blocking issues:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/reviews --method POST --field body='LGTM' --field event=APPROVE
             If blocking issues found:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || inputs.pr_number }}/reviews --method POST --field body='Changes required: [summarize issues]' --field event=REQUEST_CHANGES
             Only use REQUEST_CHANGES for significant bugs, security vulnerabilities, or breaking changes. Use APPROVE for minor issues, style comments, or suggestions.
           # CUSTOMIZE: Restrict to read-only tools
           # claude_args: "--allowedTools Bash(go vet ./...),Bash(go test ./...)"


### PR DESCRIPTION
Add a `workflow_dispatch` trigger with a required `pr_number` string input to `claude-code-review.yml`. This enables the shepherd to dispatch reviews directly via `gh workflow run` without getting HTTP 422 errors.

Changes:
- Added `workflow_dispatch` trigger with required `pr_number` string input
- Updated `concurrency.group` to use `github.event.pull_request.number || inputs.pr_number`
- Updated job `if` condition to allow `workflow_dispatch` events (bypassing the draft check)
- Updated both `gh api` calls in the prompt to use `github.event.pull_request.number || inputs.pr_number` as the PR number source

Closes #179

Generated with [Claude Code](https://claude.ai/code)