### PR TITLE
fix: dedup Changelog-skipped issues across all version tags

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -181,9 +181,9 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title | jq --arg tag "$NEW_TAG" '[.[] | select(.title | contains($tag))] | length')
+            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json title | jq '[.[] | select(.title | contains("Changelog skipped"))] | length')
             if [ "$EXISTING" -gt 0 ]; then
-              echo "Open 'Changelog skipped' issue for ${NEW_TAG} already exists; skipping duplicate creation"
+              echo "An open 'Changelog skipped' issue already exists; skipping creation for ${NEW_TAG} (existing issue covers the root cause)"
             else
               gh issue create \
                 --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \


### PR DESCRIPTION
## Summary

The dedup guard in auto-tag.yml previously checked for an open issue whose title contained the specific version tag (NEW_TAG). Since each release produces a unique tag (v0.12.5, v0.12.6, etc.), the guard never fired across versions — causing a new 'Changelog skipped' issue to be filed on every failed push.

### Change

- **Before** (line 184): jq filters by the specific tag name
- **After**: jq checks for any title containing 'Changelog skipped'

Now, before creating any 'Changelog skipped' issue, the workflow checks whether any open issue with 'Changelog skipped' in its title already exists. If one does, creation is skipped and a log message explains why.

This stops the backlog from growing while the underlying race condition is fixed.

Closes #186

Generated with [Claude Code](https://claude.ai/code)