### PR TITLE
fix: add retry loop for changelog commit push to reduce Changelog-skipped failures

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -124,24 +124,28 @@ jobs:
           git commit -m "chore: update changelog for ${NEW_TAG}"
 
           # Try to sync with origin/main and push the changelog commit.
-          # If a concurrent push caused a conflict, fall back to tagging HEAD
-          # without the changelog commit and file a notification issue.
-          CHANGELOG_PUSHED=true
-          if git pull --rebase origin main; then
-            if git push origin main; then
-              : # success
-            else
-              echo "::warning::git push origin main failed; aborting and tagging HEAD without changelog update"
-              # Undo the changelog commit so we tag the original HEAD
-              git reset --hard HEAD~1
-              CHANGELOG_PUSHED=false
+          # Retry up to 3 times with a 5-second delay to absorb concurrent
+          # push races (e.g. multiple PRs merging in rapid succession).
+          CHANGELOG_PUSHED=false
+          ORIG_MAIN_HEAD=$(git rev-parse HEAD~1)
+          cp CHANGELOG.md /tmp/CHANGELOG.md.new
+          for ATTEMPT in 1 2 3; do
+            if git pull --rebase origin main && git push origin main; then
+              CHANGELOG_PUSHED=true
+              break
             fi
-          else
-            echo "::warning::git pull --rebase failed; aborting and tagging HEAD without changelog update"
+            echo "::warning::Attempt $ATTEMPT of 3: failed to push changelog commit to origin/main"
             git rebase --abort 2>/dev/null || true
-            # Undo the changelog commit so we tag the original HEAD
-            git reset --hard HEAD~1
-            CHANGELOG_PUSHED=false
+            git reset --hard "$ORIG_MAIN_HEAD"
+            if [ "$ATTEMPT" -lt 3 ]; then
+              cp /tmp/CHANGELOG.md.new CHANGELOG.md
+              git add CHANGELOG.md
+              git commit -m "chore: update changelog for ${NEW_TAG}"
+              sleep 5
+            fi
+          done
+          if [ "$CHANGELOG_PUSHED" = "false" ]; then
+            echo "::warning::All 3 attempts failed to push changelog commit to origin/main; tagging HEAD without changelog update"
           fi
 
           # Idempotency guard: exit cleanly if a concurrent run already pushed this tag.


### PR DESCRIPTION
## Summary

Replace the single pull/push attempt in `auto-tag.yml` (lines 126-145) with a 3-attempt retry loop with 5-second sleep between attempts. This absorbs transient push races caused by concurrent PR merges.

### Changes

- **Before**: Single `git pull --rebase origin main` + `git push origin main`. Any failure immediately sets `CHANGELOG_PUSHED=false` and files a new issue.
- **After**: Up to 3 attempts, each with a 5-second sleep between. On each failure, the rebase is aborted, the changelog commit is undone, the changelog file is restored from a temp copy, and the commit is re-applied for the next attempt. Only after all 3 attempts fail does it fall back to tagging without the changelog update.

### How the retry loop works

1. Saves `ORIG_MAIN_HEAD` (commit before changelog commit) and copies `CHANGELOG.md` to a temp file
2. Attempts `git pull --rebase origin main && git push origin main`
3. On failure: aborts any in-progress rebase, resets to `ORIG_MAIN_HEAD`, and (for attempts 1-2) re-applies the changelog commit from the saved temp file, then sleeps 5 seconds
4. On success: sets `CHANGELOG_PUSHED=true` and breaks
5. After 3 failures: logs a warning; the subsequent code falls through to file a Changelog-skipped issue as before

Closes #184

Generated with [Claude Code](https://claude.ai/code)