### PR TITLE
fix: add id-token: write permission to changelog.yml

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   update-changelog:


### PR DESCRIPTION
## Summary

Add the missing `id-token: write` permission to `.github/workflows/changelog.yml` to match the pattern used by all other `claude-code-action@v1` workflows in the factory.

### Change

```yaml
permissions:
  contents: write
  id-token: write  # added
```

This permission is required by `claude-code-action@v1` for OIDC token exchange. Without it, the action may silently fail to authenticate when `changelog.yml` is manually dispatched.

Closes #190

Generated with [Claude Code](https://claude.ai/code)