### PR TITLE
fix: comment on existing Changelog-skipped issue instead of silently dropping

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -185,9 +185,13 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            EXISTING=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json title | jq '[.[] | select(.title | contains("Changelog skipped"))] | length')
-            if [ "$EXISTING" -gt 0 ]; then
-              echo "An open 'Changelog skipped' issue already exists; skipping creation for ${NEW_TAG} (existing issue covers the root cause)"
+            EXISTING_ISSUE_NUMBER=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title,createdAt | \
+              jq -r '[.[] | select(.title | contains("Changelog skipped"))] | sort_by(.createdAt) | reverse | .[0].number // empty')
+            if [ -n "$EXISTING_ISSUE_NUMBER" ]; then
+              echo "An open 'Changelog skipped' issue already exists (#${EXISTING_ISSUE_NUMBER}); adding a comment for ${NEW_TAG}"
+              gh issue comment "$EXISTING_ISSUE_NUMBER" --repo "$REPOSITORY" \
+                --body "Also failed for ${NEW_TAG} (${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}). This version will need a manual changelog update once the root cause is resolved." \
+                || echo "::warning::Failed to comment on existing issue #${EXISTING_ISSUE_NUMBER}"
             else
               gh issue create \
                 --title "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" \


### PR DESCRIPTION
## Summary

When the dedup check in auto-tag.yml finds an open 'Changelog skipped' issue, instead of silently discarding the new failure, it now:
1. Finds the most recently opened 'Changelog skipped' issue by createdAt
2. Adds a comment noting the additional version that failed and links the run URL
3. Falls back to creating a new issue only when no existing one is found (unchanged behavior)

## Changes

- .github/workflows/auto-tag.yml: Replaced the silent-drop dedup block with logic that uses gh issue comment to preserve all affected versions in one place

## Example comment added to existing issue

Also failed for v0.12.12 (run URL). This version will need a manual changelog update once the root cause is resolved.

Closes #194

Generated with [Claude Code](https://claude.ai/code)