### PR TITLE
feat: flag CHANGES_REQUESTED PRs open > 2 days in stuck-PR detector

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -86,6 +86,10 @@ jobs:
             - Any PR whose reviewDecision is APPROVED but has not been merged AND whose updatedAt
               is more than 2 hours ago (7200 seconds before current time); skip recently-approved
               PRs to avoid false positives while the shepherd completes its next cycle
+            - Any PR whose reviewDecision is CHANGES_REQUESTED and has been open > 2 days (the
+              shepherd's CHANGES_REQUESTED handling may be broken — see issues #41 and #193);
+              include the PR number, title, age in days, and links to issues #41 and #193 in the
+              filed issue body
 
             **Pass 2 — General codebase issues**:
             - Logic errors, race conditions, unhandled exceptions


### PR DESCRIPTION
Add a third stuck-PR criterion to the proactive scanner: any PR with reviewDecision CHANGES_REQUESTED that has been open more than 2 days. The filed issue body will include the PR number, title, age in days, and links to issues #41 and #193 which track the shepherd's CHANGES_REQUESTED handling bug.

Closes #197

Generated with [Claude Code](https://claude.ai/code)