### PR TITLE
feat: add gh workflow run to proactive scanner for changelog recovery

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

- Add `Bash(gh workflow run:*)` to `claude-proactive.yml` allowed tools list
- Upgrade `actions` permission from `read` to `write` (required to dispatch workflow runs)
- Add **Changelog skipped issue recovery** section to the proactive scanner prompt: detects when 2+ open "Changelog skipped" issues accumulate and automatically triggers `batch-changelog.yml`

## Behavior Change

The proactive scanner now closes the recovery loop automatically:
1. `auto-tag.yml` fails to push changelog → "Changelog skipped" issue filed
2. Proactive scanner counts open "Changelog skipped" issues
3. When count ≥ 2, scanner dispatches `gh workflow run batch-changelog.yml`
4. `batch-changelog.yml` resolves all pending issues at once

No new issue is filed for this — the workflow is triggered silently and the scanner moves on.

Closes #206

Generated with [Claude Code](https://claude.ai/code)