### PR TITLE
fix: check for existing changelog PR before filing Changelog skipped issue

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -151,6 +151,18 @@ jobs:
             fi
           else
             echo "::warning::Failed to push changelog branch ${CHANGELOG_BRANCH}"
+            # A concurrent run may have already pushed this branch and created the PR.
+            # Check before treating this as a failure that requires a notification issue.
+            EXISTING_CHANGELOG_PR=$(gh pr list \
+              --repo "$REPOSITORY" \
+              --head "$CHANGELOG_BRANCH" \
+              --state open \
+              --json number \
+              2>/dev/null | jq -r '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$EXISTING_CHANGELOG_PR" ]; then
+              echo "Concurrent run already created changelog PR #${EXISTING_CHANGELOG_PR} for ${CHANGELOG_BRANCH} — treating as success"
+              CHANGELOG_PUSHED=true
+            fi
           fi
 
           # Return to the original merge commit for tagging


### PR DESCRIPTION
## Summary

After a concurrent `auto-tag` run successfully pushes the changelog branch and creates a PR, any losing run's `git push` fails. Previously `CHANGELOG_PUSHED` stayed `false` and a spurious *Changelog skipped* notification issue was filed — even though the winning run had already handled the changelog.

## Change

In the `else` block of the failed `git push origin "$CHANGELOG_BRANCH"`, use `gh pr list --head "$CHANGELOG_BRANCH" --state open` to check whether a concurrent run already created the changelog PR. If one is found, set `CHANGELOG_PUSHED=true` so no notification issue is filed.

This directly addresses the root cause of the 11+ open *Changelog skipped* issues.

Closes #205

Generated with [Claude Code](https://claude.ai/code)
