### PR TITLE
fix: add --repo flag to gh pr merge/edit in changelog workflows

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -91,8 +91,8 @@ jobs:
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-                 gh pr merge "$PR_NUMBER" --squash --auto
-                 gh issue edit "$PR_NUMBER" --add-label "claude-task"
+                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
+                 gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
             7. After the PR is created (or if an entry already existed in step 5a), close each
                matching issue with a comment:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,8 +80,8 @@ jobs:
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-                 gh pr merge "$PR_NUMBER" --squash --auto
-                 gh issue edit "$PR_NUMBER" --add-label "claude-task"
+                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
+                 gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
             6. After the PR is created, close any open GitHub issues that were filed because the
                changelog was skipped for this tag. Search for open issues mentioning the tag and


### PR DESCRIPTION
## Summary

Both batch-changelog.yml and changelog.yml already use the PR-based approach (branch + PR + auto-merge). This PR adds the missing --repo flag to gh pr merge and gh issue edit calls inside the Claude prompts, matching the auto-tag.yml pattern.

### Changes
- batch-changelog.yml: Added --repo to gh pr merge and gh issue edit in Claude prompt
- changelog.yml: Added --repo to gh pr merge and gh issue edit in Claude prompt

### Context
Both workflows already correctly used:
1. Branch creation (checkout -b changelog/...)
2. Push to branch (git push origin CHANGELOG_BRANCH)
3. PR creation (gh pr create --base main --head CHANGELOG_BRANCH)
4. Auto-merge (gh pr merge --squash --auto)
5. Label (gh issue edit --add-label claude-task)

The --repo flag ensures commands target the correct repository regardless of GH_TOKEN context, matching auto-tag.yml behavior.

Closes #204

Generated with [Claude Code](https://claude.ai/code)