### PR TITLE
fix: use full commit message format for BREAKING CHANGE footer detection

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -73,10 +73,12 @@ jobs:
           PATCH=$(echo $LATEST | cut -d. -f3)
 
           # Analyze all commits since the last tag (handles multi-commit rebase merges)
+          # Use %B (full message) instead of %s (subject only) so BREAKING CHANGE
+          # footers in commit bodies are detected for MAJOR version bumps.
           if git rev-parse "$LATEST" >/dev/null 2>&1; then
-            MSGS=$(git log "${LATEST}..HEAD" --pretty=%s)
+            MSGS=$(git log "${LATEST}..HEAD" --pretty=%B)
           else
-            MSGS=$(git log --pretty=%s)
+            MSGS=$(git log --pretty=%B)
           fi
 
           if [ -z "$MSGS" ]; then


### PR DESCRIPTION
Use --pretty=%B instead of --pretty=%s for MSGS variable to capture BREAKING CHANGE in commit body footers.\n\nConventional Commits allows BREAKING CHANGE in footer (not just subject). Previously git log --pretty=%s only captured the subject, silently ignoring footer-based BREAKING CHANGE and causing a MINOR bump instead of MAJOR.\n\nChanges --pretty=%s to --pretty=%B (full message) for version-bump analysis. Changelog display lines intentionally keep --pretty=- %s for clean one-line entries.\n\nCloses #211\n\nGenerated with [Claude Code](https://claude.ai/code)