### PR TITLE
fix: add concurrency group to batch-changelog.yml to prevent duplicate PRs

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: batch-changelog
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write


### PR DESCRIPTION
Adds a workflow-level `concurrency` block to `batch-changelog.yml` so that if the workflow is triggered concurrently (e.g., two manual dispatches, or a proactive scanner racing with a manual trigger), the second run queues rather than both running in parallel.

`cancel-in-progress: false` is set so an in-flight batch is never interrupted mid-run — the second trigger simply waits.

**Change:**
```yaml
concurrency:
  group: batch-changelog
  cancel-in-progress: false
```

Closes #212

Generated with [Claude Code](https://claude.ai/code)