### PR TITLE
fix: use exact tag title match for changelog-skipped dedup

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -207,8 +207,8 @@ jobs:
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
             ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
               "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
-            EXISTING_ISSUE_NUMBER=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title,createdAt | \
-              jq -r '[.[] | select(.title | contains("Changelog skipped"))] | sort_by(.createdAt) | reverse | .[0].number // empty')
+            EXISTING_ISSUE_NUMBER=$(gh issue list --repo "$REPOSITORY" --state open --limit 100 --json number,title | \
+              jq -r --arg TAG "Changelog skipped for ${NEW_TAG}: failed to push changelog to main" '[.[] | select(.title == $TAG)] | .[0].number // empty')
             if [ -n "$EXISTING_ISSUE_NUMBER" ]; then
               echo "An open 'Changelog skipped' issue already exists (#${EXISTING_ISSUE_NUMBER}); adding a comment for ${NEW_TAG}"
               gh issue comment "$EXISTING_ISSUE_NUMBER" --repo "$REPOSITORY" \


### PR DESCRIPTION
Replace fuzzy `contains("Changelog skipped")` jq filter with an exact title match against `Changelog skipped for $NEW_TAG: failed to push changelog to main`. This ensures each tag gets its own issue (or comments on its own existing issue) rather than bundling multiple distinct tags into a single issue.

Also removes the now-unnecessary `sort_by(.createdAt) | reverse` pipeline since an exact match returns at most one result per tag, and drops the unused `createdAt` field from the `gh issue list` query.

**Before:**
```bash
jq -r '[.[] | select(.title | contains("Changelog skipped"))] | sort_by(.createdAt) | reverse | .[0].number // empty'
```

**After:**
```bash
jq -r --arg TAG "Changelog skipped for NEW_TAG: failed to push changelog to main" '[.[] | select(.title == $TAG)] | .[0].number // empty'
```

Closes #222

Generated with [Claude Code](https://claude.ai/code)