### PR TITLE
fix: skip code review for bot and changelog PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,11 @@ concurrency:
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      !startsWith(github.event.pull_request.title, 'chore: update changelog') &&
+      !startsWith(github.event.pull_request.title, 'chore: batch update changelog')
     steps:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Add an `if` condition to the `claude-code-review` job to skip automated PRs from `github-actions[bot]` and PRs with changelog-related titles.

## Changes

Modified `.github/workflows/claude-code-review.yml` line 21 to expand the `if` condition:

```yaml
if: >
  github.event.pull_request.draft == false &&
  github.event.pull_request.user.login != 'github-actions[bot]' &&
  !startsWith(github.event.pull_request.title, 'chore: update changelog') &&
  !startsWith(github.event.pull_request.title, 'chore: batch update changelog')
```

This prevents unnecessary API credit usage and avoids the risk of the reviewer accidentally blocking auto-merge on routine automated maintenance PRs like changelog updates.

Closes #231

Generated with [Claude Code](https://claude.ai/code)