### PR TITLE
fix: update batch-changelog prompt to parse tag from correct title format

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -51,8 +51,10 @@ jobs:
                  gh issue list --state open --search "Changelog skipped for" --json number,title --jq '.[] | "\(.number)|\(.title)"'
 
                For each result, extract the tag name from the issue title. The title format is:
-                 "Changelog skipped for <tag_name>"
-               Parse the tag by taking everything after "Changelog skipped for ".
+                 "Changelog skipped for <tag_name>: <reason>"
+               Parse the tag by taking the token immediately after "Changelog skipped for " and
+               before the first colon. For example, from the title
+               "Changelog skipped for v1.0.2: failed to push changelog to main", extract "v1.0.2".
 
             2. If no matching issues are found, print "No open Changelog-skipped issues found." and stop.
 


### PR DESCRIPTION
The Claude prompt in `.github/workflows/batch-changelog.yml` (lines 53-55) documented the issue title format as `"Changelog skipped for <tag_name>"` and instructed parsing by taking everything after that prefix.

However, actual issue titles generated by `auto-tag.yml` are:
```
Changelog skipped for v1.0.2: failed to push changelog to main
```

This caused the extracted tag to be `v1.0.2: failed to push changelog to main` instead of just `v1.0.2`, making `gh release view` fail with "release not found" and leaving the issue unresolved.

### Fix

Updated the prompt to:
1. Document the real title format: `"Changelog skipped for <tag_name>: <reason>"`
2. Instruct extraction of only the semver token before the first colon, with a concrete example

Closes #229

Generated with [Claude Code](https://claude.ai/code)