### PR TITLE
fix: handle TOCTOU race in auto-tag git push

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -180,8 +180,25 @@ jobs:
 
           # Tag the original merge commit (ORIG_HEAD, before the changelog branch commit)
           git tag $NEW_TAG
-          git push origin $NEW_TAG
-          echo "Tagged: $NEW_TAG"
+          PUSH_EXIT=0
+          git push origin $NEW_TAG || PUSH_EXIT=$?
+          if [ $PUSH_EXIT -ne 0 ]; then
+            # Push failed — check if a concurrent run beat us (TOCTOU: tag may now exist on origin)
+            if git ls-remote --tags origin "$NEW_TAG" | grep -q "$NEW_TAG"; then
+              echo "Tag $NEW_TAG push failed but tag now exists on origin (concurrent run won the race)"
+              # Check if a release already exists; if so, exit cleanly without filing a spurious issue
+              if gh release view "$NEW_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+                echo "Release also exists for $NEW_TAG — concurrent run completed successfully; exiting cleanly"
+                exit 0
+              fi
+              echo "Tag exists on origin but no release yet; proceeding to create release"
+            else
+              echo "::error::git push of tag $NEW_TAG failed and tag is not on origin"
+              exit 1
+            fi
+          else
+            echo "Tagged: $NEW_TAG"
+          fi
 
           # Ensure claude-task label exists so notification issues aren't auto-closed by stale bot
           gh label create claude-task --description 'Assigned to Claude for implementation' --color 7057ff 2>/dev/null || true
@@ -191,16 +208,21 @@ jobs:
             --title "$NEW_TAG"; then
             echo "Release created: $NEW_TAG"
           else
-            echo "::warning::gh release create failed for $NEW_TAG; tag is pushed but no GitHub release exists"
-            RELEASE_BODY=$(printf 'The `auto-tag` workflow pushed tag `%s` to the repo but `gh release create` failed (a transient network error, rate limit, or API timeout may have occurred).\n\nThe git tag exists but no GitHub release was created. To retry manually:\n\n```\ngh release create %s --generate-notes --title %s\n```\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please implement this so the factory can retry via: `gh release create %s --generate-notes --title %s`' \
-              "$NEW_TAG" "$NEW_TAG" "$NEW_TAG" \
-              "$SERVER_URL" "$REPOSITORY" "$RUN_ID" \
-              "$NEW_TAG" "$NEW_TAG")
-            gh issue create \
-              --title "Release missing for ${NEW_TAG}: gh release create failed" \
-              --body "$RELEASE_BODY" \
-              --label claude-task \
-              || echo "::warning::Failed to create notification issue for missing release"
+            # Before filing a notification issue, check if a concurrent run already created the release
+            if gh release view "$NEW_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+              echo "Release for $NEW_TAG already exists (concurrent run created it) — skipping notification issue"
+            else
+              echo "::warning::gh release create failed for $NEW_TAG; tag is pushed but no GitHub release exists"
+              RELEASE_BODY=$(printf 'The `auto-tag` workflow pushed tag `%s` to the repo but `gh release create` failed (a transient network error, rate limit, or API timeout may have occurred).\n\nThe git tag exists but no GitHub release was created. To retry manually:\n\n```\ngh release create %s --generate-notes --title %s\n```\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please implement this so the factory can retry via: `gh release create %s --generate-notes --title %s`' \
+                "$NEW_TAG" "$NEW_TAG" "$NEW_TAG" \
+                "$SERVER_URL" "$REPOSITORY" "$RUN_ID" \
+                "$NEW_TAG" "$NEW_TAG")
+              gh issue create \
+                --title "Release missing for ${NEW_TAG}: gh release create failed" \
+                --body "$RELEASE_BODY" \
+                --label claude-task \
+                || echo "::warning::Failed to create notification issue for missing release"
+            fi
           fi
 
           # Notify if changelog was skipped so a human can update it manually


### PR DESCRIPTION
## Summary

Fixes a TOCTOU (Time-Of-Check-Time-Of-Use) race condition in `.github/workflows/auto-tag.yml` lines 182-204.

**Problem:** The existing guard at line 176 exits cleanly if the tag already exists on origin, but there is a race window between that check and the actual `git push` at line 183. If a concurrent run pushes the same tag in that window, `git push` silently exits with code 1 (no error check), then `gh release create` fails because the concurrent run already created it, triggering a spurious 'Release missing for TAG' notification issue even though the release exists.

**Fix:**
1. Capture the exit code of `git push origin $NEW_TAG` using `PUSH_EXIT`
2. If push fails, re-run `ls-remote` to check if the tag now exists on origin (concurrent run won the race)
3. If tag exists on origin, check `gh release view` — if release also exists, exit cleanly (no spurious issue)
4. If tag exists but no release yet, proceed to create the release
5. If tag does not exist on origin after push failure, exit with error (genuine push failure)
6. After `gh release create` fails, also check `gh release view` before filing a notification issue, preventing spurious issues when the concurrent run creates the release between the create attempt and error handling

Closes #230

Generated with [Claude Code](https://claude.ai/code)