### PR TITLE
fix: close changelog-skipped issues via PR body Closes syntax

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -56,6 +56,9 @@ jobs:
                before the first colon. For example, from the title
                "Changelog skipped for v1.0.2: failed to push changelog to main", extract "v1.0.2".
 
+               Store the collected issue numbers (space-separated) in ISSUE_NUMBERS and the
+               corresponding tag names in TAGS for use in later steps.
+
             2. If no matching issues are found, print "No open Changelog-skipped issues found." and stop.
 
             3. If DRY_RUN is "true", print the list of issue numbers and tag names that would be
@@ -90,19 +93,24 @@ jobs:
                  git add CHANGELOG.md
                  git commit -m "chore: batch update changelog for all skipped releases"
                  git push origin "$CHANGELOG_BRANCH"
+                 CLOSES_LINES=$(for num in $ISSUE_NUMBERS; do echo "Closes #$num"; done)
+                 PR_BODY=$(printf "Automated batch changelog update. Direct pushes to main are blocked by branch protection rules.\n\n%s" "$CLOSES_LINES")
                  PR_URL=$(gh pr create \
                    --repo ${{ github.repository }} \
                    --title "chore: batch update changelog for all skipped releases" \
-                   --body "Automated batch changelog update. Direct pushes to main are blocked by branch protection rules." \
+                   --body "$PR_BODY" \
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
                  gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
                  gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
-            7. After the PR is created (or if an entry already existed in step 5a), close each
-               matching issue with a comment:
-                 gh issue close <number> --comment "Resolved: changelog entry will be merged via PR."
+            7. Do NOT manually close the issues when a PR was created. The "Closes #<N>" entries
+               in the PR body (added in step 6) will cause GitHub to auto-close them when the PR
+               merges. If the PR is closed without merging, the issues remain open for the
+               scanner to retry.
 
-            If no new entries were needed (all tags already had entries), still close any
-            matching issues and skip the git commit step.
+               Exception — if no new entries were needed (all tags already had entries in
+               CHANGELOG.md), no PR is created, so close each matching issue manually and skip
+               the git commit step:
+                 gh issue close <number> --comment "Resolved: changelog entry already exists in CHANGELOG.md."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -63,9 +63,15 @@ jobs:
 
             4. Write the updated (or newly created) CHANGELOG.md.
 
-            5. Configure git identity, create a changelog branch, commit, push, and open a PR
-               with auto-merge enabled. Direct pushes to main are blocked by branch protection
-               rules, so this follows the same pattern as auto-tag.yml:
+            5. Search for any open issues filed because the changelog was skipped for this tag.
+               Store the matching issue numbers (space-separated) in SKIP_ISSUE_NUMBERS:
+                 SKIP_ISSUE_NUMBERS=$(gh issue list --state open --search "Changelog skipped for ${{ github.event.inputs.tag_name }}" --json number --jq '.[].number' | tr '\n' ' ')
+
+               Configure git identity, create a changelog branch, commit, push, and open a PR
+               with auto-merge enabled. Build the PR body with a "Closes #<N>" line for each
+               matching issue so GitHub auto-closes them when the PR merges. Direct pushes to
+               main are blocked by branch protection rules, so this follows the same pattern as
+               auto-tag.yml:
                  git config user.name "github-actions[bot]"
                  git config user.email "github-actions[bot]@users.noreply.github.com"
                  CHANGELOG_BRANCH="changelog/${{ github.event.inputs.tag_name }}-$(date -u +%Y%m%d-%H%M%S)"
@@ -73,18 +79,18 @@ jobs:
                  git add CHANGELOG.md
                  git commit -m "chore: update changelog for ${{ github.event.inputs.tag_name }}"
                  git push origin "$CHANGELOG_BRANCH"
+                 CLOSES_LINES=$(for num in $SKIP_ISSUE_NUMBERS; do echo "Closes #$num"; done)
+                 PR_BODY=$(printf "Automated changelog update for ${{ github.event.inputs.tag_name }}. Direct pushes to main are blocked by branch protection rules.\n\n%s" "$CLOSES_LINES")
                  PR_URL=$(gh pr create \
                    --repo ${{ github.repository }} \
                    --title "chore: update changelog for ${{ github.event.inputs.tag_name }}" \
-                   --body "Automated changelog update for ${{ github.event.inputs.tag_name }}. Direct pushes to main are blocked by branch protection rules." \
+                   --body "$PR_BODY" \
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
                  gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
                  gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
-            6. After the PR is created, close any open GitHub issues that were filed because the
-               changelog was skipped for this tag. Search for open issues mentioning the tag and
-               close them with an explanatory comment:
-                 gh issue list --state open --search "Changelog skipped for ${{ github.event.inputs.tag_name }}" --json number --jq '.[].number' | xargs -I{} gh issue close {} --comment "Resolved: changelog for ${{ github.event.inputs.tag_name }} will be merged via PR."
-               If no matching issues are found, skip this step silently.
+            6. Do NOT manually close the issues. The "Closes #<N>" entries in the PR body (added
+               in step 5) will cause GitHub to auto-close them when the PR merges. If the PR is
+               closed without merging, the issues remain open for the scanner to retry.


### PR DESCRIPTION
## Summary

- batch-changelog.yml step 6: Build PR body dynamically with Closes #N for every issue number collected in step 1
- batch-changelog.yml step 7: Remove immediate gh issue close call; manual close only used as fallback when no PR is created (all entries already existed)
- changelog.yml step 5: Query open issues for the tag before creating the PR, include Closes #N in the PR body
- changelog.yml step 6: Replace manual issue close with a note explaining GitHub auto-closes via the PR body

Issues are now only closed after the changelog PR actually merges, preventing silent data loss if auto-merge fails, CI blocks the PR, or a review requests changes.

Closes #238

Generated with [Claude Code](https://claude.ai/code)