### PR TITLE
fix: add --delete-branch to changelog gh pr merge commands

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -143,7 +143,7 @@ jobs:
 
             if echo "$CHANGELOG_PR_URL" | grep -q "github.com"; then
               CHANGELOG_PR_NUMBER=$(echo "$CHANGELOG_PR_URL" | grep -oE '[0-9]+$' | tail -1)
-              gh pr merge "$CHANGELOG_PR_NUMBER" --repo "$REPOSITORY" --squash --auto 2>/dev/null || \
+              gh pr merge "$CHANGELOG_PR_NUMBER" --repo "$REPOSITORY" --squash --auto --delete-branch 2>/dev/null || \
                 echo "::warning::auto-merge not available for PR #${CHANGELOG_PR_NUMBER}; it will need manual merge"
               gh issue edit "$CHANGELOG_PR_NUMBER" --repo "$REPOSITORY" --add-label "claude-task" 2>/dev/null || true
               CHANGELOG_PUSHED=true

--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -102,7 +102,7 @@ jobs:
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
+                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto --delete-branch
                  gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
             7. Do NOT manually close the issues when a PR was created. The "Closes #<N>" entries

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -88,7 +88,7 @@ jobs:
                    --base main \
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto
+                 gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto --delete-branch
                  gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
             6. Do NOT manually close the issues. The "Closes #<N>" entries in the PR body (added


### PR DESCRIPTION
Add `--delete-branch` to all three changelog PR merge commands so that `changelog/` branches are automatically removed after the PR merges, preventing stale branch accumulation on the remote.

## Changes

- **`auto-tag.yml`** (line 146): Added `--delete-branch` to the shell script `gh pr merge` call
- **`changelog.yml`** (step 5 prompt): Added `--delete-branch` to the example `gh pr merge` command Claude is instructed to run
- **`batch-changelog.yml`** (step 6 prompt): Added `--delete-branch` to the example `gh pr merge` command Claude is instructed to run

## Why

Every release creates a `changelog/v-tag` (or `changelog/batch-timestamp`) branch. Without `--delete-branch`, these branches accumulate indefinitely. The shepherd already uses `--delete-branch` for regular PRs; this fix brings changelog PRs in line with the same cleanup behavior.

Closes #241

Generated with [Claude Code](https://claude.ai/code)
