### PR TITLE
fix: add in-flight guard to batch-changelog triggers in proactive scanners

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -94,10 +94,14 @@ jobs:
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:
               gh issue list --state open --search "Changelog skipped" --limit 50
-            Count the results. If 2 or more open "Changelog skipped" issues exist, trigger
-            the batch-changelog workflow to resolve them all at once:
+            Count the results. If 2 or more open "Changelog skipped" issues exist, first
+            check whether a batch-changelog run is already queued or in progress:
+              gh run list --workflow=batch-changelog.yml --json status --limit 10
+            Inspect the returned JSON. If any entry has status "queued" or "in_progress",
+            a run is already in flight — skip the trigger entirely and move on.
+            Only if no queued or in_progress runs exist, trigger the workflow:
               gh workflow run batch-changelog.yml
-            Do NOT file a new issue for this — just trigger the workflow and move on.
+            Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 
             **Pass 2 — General codebase issues**:
             - Logic errors, race conditions, unhandled exceptions

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -86,10 +86,14 @@ jobs:
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:
               gh issue list --state open --search "Changelog skipped" --limit 50
-            Count the results. If 2 or more open "Changelog skipped" issues exist, trigger
-            the batch-changelog workflow to resolve them all at once:
+            Count the results. If 2 or more open "Changelog skipped" issues exist, first
+            check whether a batch-changelog run is already queued or in progress:
+              gh run list --workflow=batch-changelog.yml --json status --limit 10
+            Inspect the returned JSON. If any entry has status "queued" or "in_progress",
+            a run is already in flight — skip the trigger entirely and move on.
+            Only if no queued or in_progress runs exist, trigger the workflow:
               gh workflow run batch-changelog.yml
-            Do NOT file a new issue for this — just trigger the workflow and move on.
+            Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 
             For each concrete finding across all four passes, file an issue:
               gh issue create --title "..." --body "...specific file, line or behavior, current state, desired improvement...\n\n@claude please implement this"


### PR DESCRIPTION
## Summary

Before triggering `batch-changelog.yml`, both `claude-proactive.yml` and `claude-self-improve.yml` now check whether a run is already queued or in progress. This prevents the race condition where the hourly scanner fires again while a batch-changelog PR is still open, which caused duplicate changelog PRs.

## Changes

- **`.github/workflows/claude-proactive.yml`** — Updated the 'Changelog skipped issue recovery' section to run `gh run list --workflow=batch-changelog.yml --json status --limit 10` and inspect the result. If any entry has status `queued` or `in_progress`, the trigger is skipped.
- **`.github/workflows/claude-self-improve.yml`** — Same guard added to the identical section in the weekly deep scanner.

## Why

`batch-changelog.yml` uses `concurrency: cancel-in-progress: false`, so overlapping triggers queue rather than cancel. Any proactive scan run during the open-PR window found the same open 'Changelog skipped' issues (they close only when the PR merges) and dispatched a second run, creating duplicate PRs and duplicate changelog sections.

The fix uses the already-allowed `Bash(gh run list:*)` tool — no new permissions are required.

Closes #246

Generated with [Claude Code](https://claude.ai/code)