### PR TITLE
fix: add gh label create guard and tool permission to changelog.yml

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,7 +42,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
+          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
           prompt: |
             Update CHANGELOG.md for the release ${{ github.event.inputs.tag_name }}.
 
@@ -89,6 +89,7 @@ jobs:
                    --head "$CHANGELOG_BRANCH")
                  PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
                  gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --squash --auto --delete-branch
+                 gh label create claude-task --description 'Assigned to Claude for implementation' --color 7057ff 2>/dev/null || true
                  gh issue edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "claude-task"
 
             6. Do NOT manually close the issues. The "Closes #<N>" entries in the PR body (added


### PR DESCRIPTION
Add Bash(gh label create:*) to the allowedTools list in claude_args so Claude can create the claude-task label if it does not already exist.

Add the label creation guard immediately before the gh issue edit --add-label call in prompt step 5. This mirrors the exact fix already applied to batch-changelog.yml and prevents the PR from losing the claude-task label (which would otherwise cause stale.yml to auto-close it).

Closes #255

Generated with [Claude Code](https://claude.ai/code)