### PR TITLE
chore: batch update changelog for all skipped releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v1.0.10 — 2026-03-01
+
+## What's Changed
+* fix: add gh label create guard and tool permission to changelog.yml by @greynewell in https://github.com/greynewell/claude-software-factory/pull/257
+
+
+**Full Changelog**: https://github.com/greynewell/claude-software-factory/compare/v1.0.9...v1.0.10
+
+## v1.0.9 — 2026-03-01
+
+## What's Changed
+* chore: batch update changelog for all skipped releases by @greynewell in https://github.com/greynewell/claude-software-factory/pull/254
+* fix: add duplicate-PR guard to batch-changelog.yml by @greynewell in https://github.com/greynewell/claude-software-factory/pull/258
+
+
+**Full Changelog**: https://github.com/greynewell/claude-software-factory/compare/v1.0.8...v1.0.9
+
 ## v1.0.8 — 2026-03-01
 
 ## What's Changed


### PR DESCRIPTION
Automated batch changelog update. Direct pushes to main are blocked by branch protection rules.

Closes #260
Closes #259