### PR TITLE
fix: add idempotency check when gh pr create fails after successful push

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -150,6 +150,21 @@ jobs:
               echo "Changelog PR #${CHANGELOG_PR_NUMBER} created: ${CHANGELOG_PR_URL}"
             else
               echo "::warning::Failed to create changelog PR: ${CHANGELOG_PR_URL}"
+              # A concurrent run may have already created the PR for this branch.
+              # Check before treating this as a failure that requires a notification issue.
+              EXISTING_CHANGELOG_PR=$(gh pr list \
+                --repo "$REPOSITORY" \
+                --head "$CHANGELOG_BRANCH" \
+                --state open \
+                --json number \
+                2>/dev/null | jq -r '.[0].number // empty' 2>/dev/null || true)
+              if [ -n "$EXISTING_CHANGELOG_PR" ]; then
+                echo "Existing changelog PR #${EXISTING_CHANGELOG_PR} found for ${CHANGELOG_BRANCH} — treating as success"
+                gh pr merge "$EXISTING_CHANGELOG_PR" --repo "$REPOSITORY" --squash --auto --delete-branch 2>/dev/null || \
+                  echo "::warning::auto-merge not available for PR #${EXISTING_CHANGELOG_PR}; it will need manual merge"
+                gh issue edit "$EXISTING_CHANGELOG_PR" --repo "$REPOSITORY" --add-label "claude-task" 2>/dev/null || true
+                CHANGELOG_PUSHED=true
+              fi
             fi
           else
             echo "::warning::Failed to push changelog branch ${CHANGELOG_BRANCH}"


### PR DESCRIPTION
## Summary

When `git push` succeeds but `gh pr create` fails (network error, API timeout, or concurrent-run race), the `else` branch previously only printed a warning and left `CHANGELOG_PUSHED=false`. This caused a spurious "Changelog-skipped" notification issue to be filed even though the branch existed on origin.

**Fix:** In the `else` branch of the `gh pr create` result check (inside the successful-push path), added the same idempotency check that the push-failure branch already uses:
- Run `gh pr list --head $CHANGELOG_BRANCH --state open`
- If a PR is found, set `CHANGELOG_PUSHED=true` and apply auto-merge and `claude-task` label to the existing PR

This brings the push-success path to parity with the push-failure path (lines 170-183), which already had this check.

Closes #262

Generated with [Claude Code](https://claude.ai/code)