### PR TITLE
docs: instruct Claude to checkout PR head branch when responding to PR comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,25 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 ## Branch Naming
 
 `claude/issue-{number}-{YYYYMMDD}-{HHMM}`
+
+## PR Branch Checkout
+
+When triggered by a comment or review on a **pull request**, `actions/checkout` in
+`claude.yml` resolves `github.sha` to the default branch (`main`) — not the PR head
+branch. Any file edits or commits will silently target the wrong branch unless you
+explicitly check out the PR branch first.
+
+**Before making any file changes when responding to a PR comment or review**, run:
+
+```bash
+# Get the PR head branch (replace <PR-number> with the actual PR number from context)
+PR_BRANCH=$(gh pr view <PR-number> --json headRefName -q .headRefName)
+
+# Fetch and switch to the correct branch
+git fetch origin "$PR_BRANCH"
+git checkout "$PR_BRANCH"
+```
+
+How to detect you are in a PR context: the task context will show `is_pr: true` or the
+triggering comment URL will contain `/pull/`. When unsure, run `gh pr view <number>` —
+if it succeeds, always checkout its head branch before editing any files.


### PR DESCRIPTION
## Summary

When `claude.yml` fires via `issue_comment` on a pull request, `actions/checkout@v4` resolves `github.sha` to the default branch (`main`), not the PR head branch. This means any file edits or commits made by Claude when responding to `CHANGES_REQUESTED` reviews silently land on the wrong branch.

This PR adds a **PR Branch Checkout** section to `CLAUDE.md` that instructs Claude to:
1. Detect when it is responding to a PR comment/review (via `is_pr: true` context or `/pull/` in the URL)
2. Run `gh pr view <PR-number> --json headRefName` to retrieve the correct head branch
3. Run `git fetch origin` + `git checkout <branch>` before making any file changes

Claude already has `Bash(gh pr view:*)`, `Bash(git fetch:*)`, and `Bash(git checkout:*)` in its allowed tools list in `claude.yml` — this fix gives it the instruction to actually use them in this context.

> **Note:** Modifying `.github/workflows/claude.yml` directly to add a conditional checkout step is not possible due to GitHub App permission restrictions on workflow files. The `CLAUDE.md` instruction approach (also suggested in the issue) is the viable alternative.

Closes #263

Generated with [Claude Code](https://claude.ai/code)