### PR TITLE
fix: add Bash(date:*) to allowedTools in batch-changelog.yml and changelog.yml

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -39,7 +39,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh pr list:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh pr list:*),Bash(date:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
           prompt: |
             Batch-update CHANGELOG.md for all open "Changelog skipped" issues.
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,7 +42,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
+          claude_args: '--allowedTools "Bash(gh release view:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(git pull:*),Bash(git checkout:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue edit:*),Bash(gh label create:*),Bash(date:*),Read,Write(CHANGELOG.md),Edit(CHANGELOG.md)"'
           prompt: |
             Update CHANGELOG.md for the release ${{ github.event.inputs.tag_name }}.
 


### PR DESCRIPTION
Both `batch-changelog.yml` and `changelog.yml` instruct Claude to generate timestamp-based branch names using `date -u +%Y%m%d-%H%M%S`, but neither workflow included `Bash(date:*)` in its `allowedTools` list. Without this permission, Claude cannot execute `date`, so branch creation fails.

## Changes

- `batch-changelog.yml` line 42: added `Bash(date:*)` to `allowedTools`
- `changelog.yml` line 45: added `Bash(date:*)` to `allowedTools`

This matches the fix already applied to the shepherd in issue #97.

Closes #268

Generated with [Claude Code](https://claude.ai/code)