### PR TITLE
fix: skip APPROVED stuck-PR check when CI is failing or in-progress

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.
@@ -85,7 +85,13 @@ jobs:
               the review workflow is broken)
             - Any PR whose reviewDecision is APPROVED but has not been merged AND whose updatedAt
               is more than 2 hours ago (7200 seconds before current time); skip recently-approved
-              PRs to avoid false positives while the shepherd completes its next cycle
+              PRs to avoid false positives while the shepherd completes its next cycle.
+              For each such PR, before filing an issue, check its CI status:
+                gh pr checks <number> --repo ${{ github.repository }} --json name,state
+              Skip the PR (do NOT file an issue) if any check has state "FAILING", "PENDING",
+              "IN_PROGRESS", or "QUEUED" — a failing or in-progress CI is a legitimate reason
+              the shepherd has not merged yet. Only flag a PR as stuck if all checks are passing
+              (state "SUCCESS") but the PR still has not been merged.
             - Any PR whose reviewDecision is CHANGES_REQUESTED and has been open > 2 days (the
               shepherd's CHANGES_REQUESTED handling may be broken — see issues #41 and #193);
               include the PR number, title, age in days, and links to issues #41 and #193 in the


### PR DESCRIPTION
## Summary

The proactive scanner was filing false-positive 'stuck PR' issues for APPROVED PRs when CI was failing. The shepherd correctly refuses to merge in that case, but the scanner did not check CI status — so it would file a new noise issue every hour.

### Changes

- **claude-proactive.yml**: Updated the APPROVED stuck-PR prompt bullet to instruct the scanner to run 'gh pr checks <number>' before filing an issue. If any check is failing, pending, in-progress, or queued, the PR is skipped. Only PRs with all checks passing are flagged as stuck.
- **claude_args**: Added 'Bash(gh pr checks:*)' to the allowed tools so the scanner can actually run the new command.

Closes #272

Generated with [Claude Code](https://claude.ai/code)