### PR TITLE
fix: replace exit 0 shell snippet with natural-language stop instruction in batch-changelog.yml

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -86,10 +86,11 @@ jobs:
                Before creating a branch, check whether an open batch changelog PR already exists
                to avoid duplicate PRs in case the scanner re-triggers before a previous run merges:
                  EXISTING_PR=$(gh pr list --repo ${{ github.repository }} --state open --search "chore: batch update changelog" --json number --jq '.[0].number // empty')
-                 if [ -n "$EXISTING_PR" ]; then
-                   echo "Open batch changelog PR #$EXISTING_PR already exists -- skipping to avoid duplicate"
-                   exit 0
-                 fi
+
+               If EXISTING_PR is non-empty, print "Open batch changelog PR #<EXISTING_PR> already
+               exists — skipping to avoid duplicate" and stop all further processing immediately.
+               Do not create a branch, do not commit, do not push, and do not open a new PR.
+               All remaining steps below are skipped; the task is complete.
 
                Configure git identity, create a changelog branch, commit, push, and open a PR
                with auto-merge enabled. Direct pushes to main are blocked by branch protection


### PR DESCRIPTION
## Summary

- The duplicate-PR guard in batch-changelog.yml (lines 86-92) used a Bash if/exit 0 snippet inside the Claude prompt
- When Claude executed this as a Bash tool call, exit 0 only exited the shell subprocess — Claude itself was not halted and could continue, creating a duplicate PR
- Replaced the shell snippet with an explicit, unambiguous natural-language instruction telling Claude to stop all further processing if an existing PR is found
- The gh pr list command that detects existing PRs is retained; only the if/exit 0 conditional is removed and replaced with natural language

## Changes

- .github/workflows/batch-changelog.yml: Removed shell if/exit 0 block, replaced with clear stop instruction in prose form

Closes #286

Generated with [Claude Code](https://claude.ai/code)