### PR TITLE
fix: extend skip guard regex to cover batch-changelog commits

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Skip if this is an automated changelog update to prevent recursive triggering
           HEAD_MSG=$(git log -1 --pretty=%s)
-          if echo "$HEAD_MSG" | grep -qE "^chore: update changelog"; then
+          if echo "$HEAD_MSG" | grep -qE "^chore: (update|batch update) changelog"; then
             echo "Skipping: this is an automated changelog update commit"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Extends the skip guard regex in `auto-tag.yml` (line 63) to also match batch-changelog merge commit subjects, preventing unnecessary CI runs when a batch-changelog PR squash-merges to main.

### Change

**Before:**
```bash
if echo "$HEAD_MSG" | grep -qE "^chore: update changelog"; then
```

**After:**
```bash
if echo "$HEAD_MSG" | grep -qE "^chore: (update|batch update) changelog"; then
```

### Why

When `batch-changelog.yml` squash-merges to main, the commit subject is `chore: batch update changelog for all skipped releases`. The old regex only matched `chore: update changelog`, so the skip guard was bypassed and auto-tag performed a full version-bump analysis only to exit with "No version bump needed" — wasting CI minutes on every batch-changelog merge.

This is a defense-in-depth complement to issues #213 and #121.

Closes #293

Generated with [Claude Code](https://claude.ai/code)