### PR TITLE
fix: skip all shepherd actions for non-claude-task PRs at start of loop

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -34,6 +34,8 @@ jobs:
               gh pr list --repo ${{ github.repository }} --state open --limit 100 --json number,title,isDraft,mergeable,labels
 
             For each non-draft PR:
+            0. Label guard: Before any other action, inspect the labels array returned by the listing command above.
+               If none of the label objects in the labels array has name equal to "claude-task", skip ALL remaining steps for this PR immediately — do not post any comments, do not check CI, do not check conflicts, do not request reviews, do not attempt to merge. Move on to the next PR.
             1. Check CI: Run gh pr checks <number> --repo ${{ github.repository }} and evaluate the output carefully before proceeding:
                - If the output is empty (no checks listed), CI has not started yet → SKIP this PR entirely, do not merge
                - If any check shows a status of "pending" or "in_progress", CI is still running → SKIP this PR, do not merge


### PR DESCRIPTION
## Summary

Add a **label guard (step 0)** at the top of the per-PR processing loop in `claude-pr-shepherd.yml`.

Previously, steps 1 (CI failure comments), 3 (merge conflict alerts), 5 (CHANGES_REQUESTED reminders), and 6 (review requests) ran for every open non-draft PR regardless of labels — causing the shepherd bot to spam notifications on human-authored PRs, dependabot PRs, and any other non-factory PR.

The new step 0 checks the `labels` array already fetched by `gh pr list` and immediately skips all remaining steps if the PR lacks the `claude-task` label — no comments posted, no CI checks run, no merge attempted.

The existing label guard in step 4 is retained as defense-in-depth.

## Changes

- `.github/workflows/claude-pr-shepherd.yml`: Added step 0 label guard before step 1

Closes #299

Generated with [Claude Code](https://claude.ai/code)
