### PR TITLE
fix: correct stuck-PR CI check state string from FAILING to FAILURE

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -96,7 +96,7 @@ jobs:
               is less than 7200 seconds, to avoid false positives while the shepherd catches up.
               For each such PR, before filing an issue, check its CI status:
                 gh pr checks <number> --repo ${{ github.repository }} --json name,state
-              Skip the PR (do NOT file an issue) if any check has state "FAILING", "PENDING",
+              Skip the PR (do NOT file an issue) if any check has state "FAILURE", "PENDING",
               "IN_PROGRESS", or "QUEUED" — a failing or in-progress CI is a legitimate reason
               the shepherd has not merged yet. Only flag a PR as stuck if all checks are passing
               (state "SUCCESS") but the PR still has not been merged.


### PR DESCRIPTION
## Summary

The stuck-PR detection prompt in `claude-proactive.yml` used `"FAILING"` as the skip condition for CI checks, but `gh pr checks --json name,state` returns `"FAILURE"` (GitHub's actual enum value). The string `"FAILING"` never appears in the JSON output.

**Root cause:** String mismatch between the prompt instruction and the actual GitHub API response.

**Effect:** The scanner never matched a failing check state, so it would file spurious "stuck PR" issues even when CI was actively failing — the opposite of the intended behavior.

**Fix:** Changed `"FAILING"` → `"FAILURE"` on line 99 of `.github/workflows/claude-proactive.yml`.

The valid states returned by `gh pr checks --json name,state` are: `SUCCESS`, `FAILURE`, `PENDING`, `IN_PROGRESS`, `QUEUED`, `CANCELLED`, `SKIPPED`, `NEUTRAL` — all other skip-state strings in the prompt (`PENDING`, `IN_PROGRESS`, `QUEUED`) were already correct.

Closes #300

Generated with [Claude Code](https://claude.ai/code)