### PR TITLE
fix: add --label claude-task to gh issue create in scanner prompts

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -124,7 +124,7 @@ jobs:
             - Dead code or unused files
 
             For each finding, file an issue:
-              gh issue create --title "..." --body "...specific file, current behavior, desired behavior...\n\n@claude please implement this"
+              gh issue create --title "..." --body "...specific file, current behavior, desired behavior...\n\n@claude please implement this" --label claude-task
 
             File at most 3 issues per run. Prioritize factory self-improvement over general bugs.
             Zero issues is fine if nothing concrete warrants attention.

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -96,7 +96,7 @@ jobs:
             Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 
             For each concrete finding across all four passes, file an issue:
-              gh issue create --title "..." --body "...specific file, line or behavior, current state, desired improvement...\n\n@claude please implement this"
+              gh issue create --title "..." --body "...specific file, line or behavior, current state, desired improvement...\n\n@claude please implement this" --label claude-task
 
             File at most 5 issues per run. Prioritize findings that improve the factory loop itself.
             Prefer specific, actionable issues over vague observations.


### PR DESCRIPTION
Add `--label claude-task` directly to the `gh issue create` command template in both `claude-proactive.yml` and `claude-self-improve.yml`.

## Problem

Filed issues only received the `claude-task` label if `claude-auto-assign.yml` successfully fired and detected `@claude` in the body. A transient failure (permission error, rate limit, outage) would leave the issue unlabeled, making it eligible for stale auto-close after 14/21 days — silently dropping valid improvement tasks.

## Fix

- `claude-proactive.yml` line 127: added `--label claude-task`
- `claude-self-improve.yml` line 99: added `--label claude-task`

Labeling is now atomic with issue creation, following the pattern already established in `auto-tag.yml`.

Closes #305

Generated with [Claude Code](https://claude.ai/code)