### PR TITLE
fix: skip no-review-decision stuck-PR when claude-code-review CI is FAILURE

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -82,7 +82,12 @@ jobs:
               gh pr list --repo ${{ github.repository }} --state open --json number,title,createdAt,updatedAt,reviewDecision
             Flag and file an issue for each of the following (if no open issue already covers it):
             - Any PR that has been open > 2 days without a review decision (scanner is blind or
-              the review workflow is broken)
+              the review workflow is broken). Before filing, check CI status for the PR:
+                gh pr checks <number> --repo ${{ github.repository }} --json name,state
+              Skip the PR (do NOT file an issue) if the claude-code-review check has state
+              "FAILURE" — a failing code review CI is the root cause and is already tracked by
+              existing open issues. Only flag a PR as stuck-no-review if the claude-code-review
+              check is absent or has a non-FAILURE state.
             - Any PR whose reviewDecision is APPROVED but has not been merged AND whose most
               recent APPROVED review was submitted more than 2 hours ago (7200 seconds before
               current time). Do NOT use updatedAt for this check — shepherd bot comments refresh


### PR DESCRIPTION
## Summary

Before filing a stuck-no-review issue, the scanner now checks `gh pr checks` to see if the `claude-code-review` check has `FAILURE` state. If so, the PR is skipped — the failing CI is the root cause, already tracked by existing open issues.

## Changes

- **`.github/workflows/claude-proactive.yml`**: Added CI-state gate to the no-review-decision branch of the stuck-PR check. Mirrors the existing gate already used for the approved-but-not-merged check (lines 102-107).

## Before / After

**Before**: Any PR open > 2 days without a review decision would trigger a stuck-PR issue, even if `claude-code-review` was in FAILURE state.

**After**: Before filing, the scanner runs `gh pr checks <number> --json name,state` and skips the PR if the `claude-code-review` check shows `FAILURE`. Only PRs where the review CI is absent or non-failing get flagged as stuck-no-review.

Closes #309

Generated with [Claude Code](https://claude.ai/code)