### PR TITLE
fix: add waiting to in-flight status check for batch-changelog runs

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -111,9 +111,9 @@ jobs:
             Count the results. If 2 or more open "Changelog skipped" issues exist, first
             check whether a batch-changelog run is already queued or in progress:
               gh run list --workflow=batch-changelog.yml --json status --limit 10
-            Inspect the returned JSON. If any entry has status "queued" or "in_progress",
+            Inspect the returned JSON. If any entry has status "queued", "in_progress", or "waiting",
             a run is already in flight — skip the trigger entirely and move on.
-            Only if no queued or in_progress runs exist, trigger the workflow:
+            Only if no queued, in_progress, or waiting runs exist, trigger the workflow:
               gh workflow run batch-changelog.yml
             Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -89,9 +89,9 @@ jobs:
             Count the results. If 2 or more open "Changelog skipped" issues exist, first
             check whether a batch-changelog run is already queued or in progress:
               gh run list --workflow=batch-changelog.yml --json status --limit 10
-            Inspect the returned JSON. If any entry has status "queued" or "in_progress",
+            Inspect the returned JSON. If any entry has status "queued", "in_progress", or "waiting",
             a run is already in flight — skip the trigger entirely and move on.
-            Only if no queued or in_progress runs exist, trigger the workflow:
+            Only if no queued, in_progress, or waiting runs exist, trigger the workflow:
               gh workflow run batch-changelog.yml
             Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 


### PR DESCRIPTION
## Summary

- Extends the changelog skipped issue recovery check in `claude-proactive.yml` and `claude-self-improve.yml` to treat a batch-changelog run with `waiting` status as already in-flight
- Previously only `queued` and `in_progress` statuses were checked; `waiting` (used by GitHub Actions when a concurrency group holds the lock) was missed
- This prevents duplicate batch-changelog runs from being queued when one is already waiting for the concurrency lock

## Changes

- `.github/workflows/claude-proactive.yml`: Added `"waiting"` to the in-flight status check in the Changelog skipped issue recovery section
- `.github/workflows/claude-self-improve.yml`: Same change in the same section

Closes #310

Generated with [Claude Code](https://claude.ai/code)
