### PR TITLE
fix: treat timed_out and error CI states as blocking in pr-shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -39,7 +39,7 @@ jobs:
             1. Check CI: Run gh pr checks <number> --repo ${{ github.repository }} and evaluate the output carefully before proceeding:
                - If the output is empty (no checks listed), CI has not started yet → SKIP this PR entirely, do not merge
                - If any check shows a status of "pending" or "in_progress", CI is still running → SKIP this PR, do not merge
-               - If any check shows a status of "fail" or "cancelled", CI has failed → do NOT merge; instead apply timestamp-aware de-dup:
+               - If any check shows a status of "fail", "cancelled", "timed_out", or "error", CI has failed → do NOT merge; instead apply timestamp-aware de-dup:
                  Get the timestamp of the most recent "CI checks are failing" comment:
                    Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '[.[] | select(.body | contains("CI checks are failing"))] | max_by(.created_at) | .created_at'
                    (Returns an ISO timestamp string, or null if no such comment exists)
@@ -47,11 +47,11 @@ jobs:
                    Run: gh pr view <number> --repo ${{ github.repository }} --json commits --jq '.commits[-1].committedDate'
                  If the most recent "CI checks are failing" comment timestamp is non-empty AND is more recent than (or equal to) the last commit timestamp, skip to the next PR without posting (de-dup: already notified for this push).
                  Otherwise (no such comment exists, OR the comment predates the latest commit), extract the failing check names and post a comment:
-                   failing_checks=$(gh pr checks <number> --repo ${{ github.repository }} --json name,state --jq '[.[] | select(.state == "fail" or .state == "cancelled") | "- \(.name) (\(.state))"] | join("\n")')
+                   failing_checks=$(gh pr checks <number> --repo ${{ github.repository }} --json name,state --jq '[.[] | select(.state == "fail" or .state == "cancelled" or .state == "timed_out" or .state == "error") | "- \(.name) (\(.state))"] | join("\n")')
                    printf '@claude CI checks are failing on this PR. Failing checks:\n%s\nPlease review the failed checks and push a fix.' "${failing_checks}" > /tmp/ci_failure_body.txt
                    gh pr comment <number> --repo ${{ github.repository }} --body-file /tmp/ci_failure_body.txt
                - Checks with status "skipping", "skipped", or "neutral" are non-blocking — treat them as passing
-               - CI passes when: at least one check is present, no check shows "fail" or "cancelled", and every non-skipped check shows "pass" or "success"
+               - CI passes when: at least one check is present, no check shows "fail", "cancelled", "timed_out", or "error", and every non-skipped check shows "pass" or "success"
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), apply timestamp-aware de-dup:
                Get the timestamp of the most recent "merge conflicts" comment:


### PR DESCRIPTION
## Summary

Extend step 1 CI evaluation in `claude-pr-shepherd.yml` to handle two additional terminal GitHub Actions states (`timed_out`, `error`) identically to `fail` and `cancelled`.

Previously these states caused PRs to silently stick indefinitely with no comment, as they did not match any branch in the shepherd logic — not fail/cancelled (no comment posted), not pending/in_progress (no wait), and not passing (merge blocked).

### Changes

- **Blocking-states prose** (line 42): add `timed_out` and `error` to the list of states that trigger a CI failure comment
- **jq `select()` filter** (line 50): extend to include `timed_out` and `error` so `failing_checks` is populated and the comment is posted
- **CI-passes prose** (line 54): add `timed_out` and `error` to the exclusion clause

Closes #319

Generated with [Claude Code](https://claude.ai/code)