### PR TITLE
fix: replace hardcoded issue refs #41/#193 in stuck-CHANGES_REQUESTED prompt

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -106,9 +106,10 @@ jobs:
               the shepherd has not merged yet. Only flag a PR as stuck if all checks are passing
               (state "SUCCESS") but the PR still has not been merged.
             - Any PR whose reviewDecision is CHANGES_REQUESTED and has been open > 2 days (the
-              shepherd's CHANGES_REQUESTED handling may be broken — see issues #41 and #193);
-              include the PR number, title, age in days, and links to issues #41 and #193 in the
-              filed issue body
+              shepherd may not be re-requesting a review after the author pushes a fix — check
+              whether claude-pr-shepherd.yml correctly handles stale CHANGES_REQUESTED reviews
+              and whether the merge step is reached after CHANGES_REQUESTED resolves);
+              include the PR number, title, and age in days in the filed issue body
 
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:


### PR DESCRIPTION
Removes hardcoded references to issues #41 and #193 from the scanner prompt in `claude-proactive.yml`. Those issue numbers will become misleading context once the referenced issues close.

Replaces the references with a plain description of the shepherd behavior to investigate, so any future stuck-CHANGES_REQUESTED issue filed by the scanner remains actionable regardless of whether the original tracking issues are open or closed.

`claude-self-improve.yml` was also checked — it does not contain these references.

Closes #320

Generated with [Claude Code](https://claude.ai/code)