### PR TITLE
fix: add Bash(gh api:*) and Bash(gh pr checks:*) to claude-self-improve allowedTools

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh api:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory conducting its weekly deep self-improvement scan.
             This repo IS the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

Adds two missing tool permissions to the weekly deep scanner's `allowedTools` list in `claude-self-improve.yml`:

- `Bash(gh api:*)` — enables Pass 4 to call `gh api repos/{owner}/{repo}/pulls/{number}/reviews` and `gh api repos/{owner}/{repo}/issues/{number}/comments` for cross-PR review history analysis
- `Bash(gh pr checks:*)` — enables Pass 4 to check CI status per PR for comprehensive failure pattern analysis

These tools were already available in the hourly proactive scanner (`claude-proactive.yml`) but were missing from the weekly deep scanner, making Pass 4 a shallow scan.

## Change

Line 28 of `.github/workflows/claude-self-improve.yml` — the `claude_args` `allowedTools` field — now includes the two additional bash tool patterns, grouped with the other `gh` commands.

Closes #325

Generated with [Claude Code](https://claude.ai/code)