### PR TITLE
fix: add Bash(gh pr checks:*) to allowedTools in claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api:*),Bash(gh pr checks:*),Read,Glob,Grep"'
           prompt: |
             Review this pull request for:
             1. Correctness and logic errors


### PR DESCRIPTION
Adds Bash(gh pr checks:*) to the allowedTools list in the Claude Code Review workflow. This is a prerequisite for implementing a CI status gate (issue #221), enabling the reviewer to check CI check statuses before submitting an APPROVE review.

Closes #326

Generated with [Claude Code](https://claude.ai/code)
