### PR TITLE
fix: add Bash(git tag:*) to claude.yml allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,5 +48,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh issue:*),Bash(gh release:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh issue:*),Bash(gh release:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(git tag:*),Bash(find:*),Bash(python3:*),Edit,Write,Read,Glob,Grep"'
           # CUSTOMIZE: Add your stack's build/lint/test commands to the allowedTools list above


### PR DESCRIPTION
## Summary

Adds `Bash(git tag:*)` to the `allowedTools` list in `.github/workflows/claude.yml`.

When `auto-tag.yml` fails to push a git tag and files a notification issue asking @claude to retry, Claude needs permission to run `git tag` commands. Without this entry in `allowedTools`, Claude cannot execute the retry instructions and the issue remains open indefinitely.

The fix inserts `Bash(git tag:*)` after the existing `Bash(git status:*)` entry on line 51.

Closes #331

Generated with [Claude Code](https://claude.ai/code)