### PR TITLE
fix: capture git push and gh pr create error output in Changelog skipped notifications

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -128,12 +128,15 @@ jobs:
           git add CHANGELOG.md
           CHANGELOG_PUSHED=false
           CHANGELOG_PR_NUMBER=""
+          CHANGELOG_FAIL_DETAILS=""
           ORIG_HEAD=$(git rev-parse HEAD)
           CHANGELOG_BRANCH="changelog/${NEW_TAG}"
           git checkout -b "$CHANGELOG_BRANCH"
           git commit -m "chore: update changelog for ${NEW_TAG}"
 
-          if git push origin "$CHANGELOG_BRANCH"; then
+          PUSH_CHANGELOG_OUTPUT=$(git push origin "$CHANGELOG_BRANCH" 2>&1)
+          PUSH_CHANGELOG_EXIT=$?
+          if [ "$PUSH_CHANGELOG_EXIT" -eq 0 ]; then
             CHANGELOG_PR_BODY=$(printf 'Automated changelog update for release %s.\n\nThis PR was created by the `auto-tag` workflow because direct pushes to `main` are protected by branch rules.\n\n_Auto-generated — do not edit._' "${NEW_TAG}")
             CHANGELOG_PR_OUTPUT=$(gh pr create \
               --repo "$REPOSITORY" \
@@ -170,6 +173,8 @@ jobs:
                   echo "::warning::auto-merge not available for PR #${EXISTING_CHANGELOG_PR}; it will need manual merge"
                 gh issue edit "$EXISTING_CHANGELOG_PR" --repo "$REPOSITORY" --add-label "claude-task" 2>/dev/null || true
                 CHANGELOG_PUSHED=true
+              else
+                CHANGELOG_FAIL_DETAILS=$(printf 'gh pr create exit code: %s\n\ngh pr create output:\n```\n%s\n```' "$PR_EXIT" "$CHANGELOG_PR_OUTPUT")
               fi
             fi
           else
@@ -185,6 +190,8 @@ jobs:
             if [ -n "$EXISTING_CHANGELOG_PR" ]; then
               echo "Concurrent run already created changelog PR #${EXISTING_CHANGELOG_PR} for ${CHANGELOG_BRANCH} — treating as success"
               CHANGELOG_PUSHED=true
+            else
+              CHANGELOG_FAIL_DETAILS=$(printf 'git push exit code: %s\n\ngit push output:\n```\n%s\n```' "$PUSH_CHANGELOG_EXIT" "$PUSH_CHANGELOG_OUTPUT")
             fi
           fi
 
@@ -267,8 +274,8 @@ jobs:
 
           # Notify if changelog was skipped so a human can update it manually
           if [ "$CHANGELOG_PUSHED" = "false" ]; then
-            ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because pushing the changelog commit to `main` failed (a concurrent push or transient network error may have occurred during the workflow run).\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
-              "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
+            ISSUE_BODY=$(printf 'The `auto-tag` workflow tagged and released `%s` but could not update `CHANGELOG.md` because the changelog branch push or PR creation failed.\n\n%s\n\nThe tag and GitHub release were created from the original HEAD. Please update `CHANGELOG.md` manually or trigger the `changelog.yml` workflow.\n\nWorkflow run: %s/%s/actions/runs/%s\n\n@claude please run the changelog.yml workflow for this tag and close this issue once done.' \
+              "$NEW_TAG" "$CHANGELOG_FAIL_DETAILS" "$SERVER_URL" "$REPOSITORY" "$RUN_ID")
             EXISTING_ISSUE_NUMBER=$(gh issue list --repo "$REPOSITORY" --state open \
               --search "\"Changelog skipped for ${NEW_TAG}\" in:title" \
               --json number,title | \
@@ -276,7 +283,7 @@ jobs:
             if [ -n "$EXISTING_ISSUE_NUMBER" ]; then
               echo "An open 'Changelog skipped' issue already exists (#${EXISTING_ISSUE_NUMBER}); adding a comment for ${NEW_TAG}"
               gh issue comment "$EXISTING_ISSUE_NUMBER" --repo "$REPOSITORY" \
-                --body "Also failed for ${NEW_TAG} (${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}). This version will need a manual changelog update once the root cause is resolved." \
+                --body "$(printf 'Also failed for %s (%s/%s/actions/runs/%s). This version will need a manual changelog update once the root cause is resolved.\n\n%s' "$NEW_TAG" "$SERVER_URL" "$REPOSITORY" "$RUN_ID" "$CHANGELOG_FAIL_DETAILS")" \
                 || echo "::warning::Failed to comment on existing issue #${EXISTING_ISSUE_NUMBER}"
             else
               gh issue create \


### PR DESCRIPTION
## Summary

- Initializes a `CHANGELOG_FAIL_DETAILS` variable before the changelog push/PR creation block
- Captures stdout+stderr and exit code from `git push origin $CHANGELOG_BRANCH` (previously swallowed)
- When `gh pr create` fails and no concurrent PR exists, stores the already-captured `CHANGELOG_PR_OUTPUT` and `PR_EXIT` into `CHANGELOG_FAIL_DETAILS`
- When `git push` fails and no concurrent PR exists, stores `PUSH_CHANGELOG_OUTPUT` and `PUSH_CHANGELOG_EXIT` into `CHANGELOG_FAIL_DETAILS`
- Includes `CHANGELOG_FAIL_DETAILS` (with exit code + raw output in a code block) in both new Changelog skipped issue bodies and comments appended to existing issues

This allows @claude and humans to immediately see the real error (authentication failure, branch protection rejection, API rate limit, etc.) rather than a generic 'concurrent push or transient network error' message.

Closes #332

Generated with [Claude Code](https://claude.ai/code)