### PR TITLE
fix: skip batch-changelog trigger when open PR already exists

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -119,7 +119,10 @@ jobs:
               gh run list --workflow=batch-changelog.yml --json status --limit 10
             Inspect the returned JSON. If any entry has status "queued", "in_progress", or "waiting",
             a run is already in flight — skip the trigger entirely and move on.
-            Only if no queued, in_progress, or waiting runs exist, trigger the workflow:
+            Next, check whether an open batch-changelog PR already exists:
+              gh pr list --state open --search 'chore: batch update changelog' --json number --jq 'length'
+            If the result is 1 or more, an open PR already exists — skip the trigger and move on.
+            Only if no queued, in_progress, or waiting runs exist AND no open PR exists, trigger the workflow:
               gh workflow run batch-changelog.yml
             Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 


### PR DESCRIPTION
## Summary

Add a check for an open batch-changelog PR before triggering `batch-changelog.yml` in the hourly proactive scanner. This prevents wasted Claude API credits from runs that start, detect the open PR via the existing dedup guard, and immediately exit.

### Changes

In `.github/workflows/claude-proactive.yml` (Changelog skipped issue recovery section), after checking for queued/in_progress/waiting runs, now also check:

```bash
gh pr list --state open --search 'chore: batch update changelog' --json number --jq 'length'
```

If the result is 1 or more, an open PR already exists and the trigger is skipped.

### Before

The check only skipped triggering if a run was currently queued/in_progress/waiting. Once the run completed and created a PR, subsequent hourly scans would trigger a new run every hour until the PR merged.

### After

The check also skips triggering if an open batch-changelog PR already exists, eliminating the wasted hourly runs.

Closes #339

Generated with [Claude Code](https://claude.ai/code)