### PR TITLE
fix: use uppercase state values in gh pr checks jq filter

### DIFF
--- a/.github/workflows/batch-changelog.yml
+++ b/.github/workflows/batch-changelog.yml
@@ -97,10 +97,10 @@ jobs:
                Then continue to the git/PR steps below (do not close, do not block; treat this PR as unrelated and proceed as if no existing batch changelog PR was found).
 
                If EXISTING_PR_TITLE matches, check whether that PR has any failing CI checks.
-               Note: gh pr checks --json state only returns the values "pass", "fail", "pending",
-               and "skipping" — other values are not used by this field.
+               Note: gh pr checks --json state returns uppercase values such as "SUCCESS",
+               "FAILURE", "CANCELLED", "TIMED_OUT", "PENDING", and "SKIPPED".
                Capture the output and exit code separately so failures are observable:
-                 CHECKS_OUTPUT=$(gh pr checks "$EXISTING_PR" --repo ${{ github.repository }} --json state --jq '[.[] | select(.state == "fail")] | length' 2>&1)
+                 CHECKS_OUTPUT=$(gh pr checks "$EXISTING_PR" --repo ${{ github.repository }} --json state --jq '[.[] | select(.state == "FAILURE" or .state == "CANCELLED" or .state == "TIMED_OUT")] | length' 2>&1)
                  CHECKS_EXIT=$?
 
                If CHECKS_EXIT is non-zero or CHECKS_OUTPUT is not a plain integer, print a warning


### PR DESCRIPTION
The jq filter in `batch-changelog.yml` step 6 used lowercase `"fail"` to detect failing CI checks, but `gh pr checks --json state` returns uppercase values (`FAILURE`, `CANCELLED`, `TIMED_OUT`, etc.). This caused `CHECKS_OUTPUT` to always be `0`, making the "close stuck PR with failing CI" branch dead code.

**Changes:**
- Updated jq filter from `select(.state == "fail")` to `select(.state == "FAILURE" or .state == "CANCELLED" or .state == "TIMED_OUT")`
- Corrected the inline note to document that `gh pr checks --json state` returns uppercase values, consistent with how `claude-pr-shepherd.yml` handles these values

Closes #343

Generated with [Claude Code](https://claude.ai/code)