### PR TITLE
fix: add open PR existence check to claude-self-improve.yml changelog recovery

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -91,7 +91,10 @@ jobs:
               gh run list --workflow=batch-changelog.yml --json status --limit 10
             Inspect the returned JSON. If any entry has status "queued", "in_progress", or "waiting",
             a run is already in flight — skip the trigger entirely and move on.
-            Only if no queued, in_progress, or waiting runs exist, trigger the workflow:
+            Next, check whether an open batch-changelog PR already exists:
+              gh pr list --state open --search 'chore: batch update changelog' --json number --jq 'length'
+            If the result is 1 or more, an open PR already exists — skip the trigger and move on.
+            Only if no queued, in_progress, or waiting runs exist AND no open PR exists, trigger the workflow:
               gh workflow run batch-changelog.yml
             Do NOT file a new issue for this — just trigger the workflow (or skip it) and move on.
 


### PR DESCRIPTION
Mirror the open PR existence check from claude-proactive.yml into the weekly deep scanner's changelog skipped issue recovery section.

Added a gh pr list check in claude-self-improve.yml (after the existing queued/in-progress run check) that detects whether a 'chore: batch update changelog' PR is already open. Updated the trigger condition to require both no queued/in-progress/waiting runs AND no open PR.

Closes #344

Generated with [Claude Code](https://claude.ai/code)