### PR TITLE
fix: remove overly broad Bash(gh issue:*) from shepherd allowedTools

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh issue:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
           prompt: |
             You are a PR shepherd for the repo ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary

Remove `Bash(gh issue:*)` from `claude-pr-shepherd.yml`'s `allowedTools` in `claude_args`.

The shepherd never uses any `gh issue` subcommands directly:
- Issue comment checks use `gh api repos/.../issues/<N>/comments` (covered by `Bash(gh api:*)`)
- PR comments use `gh pr comment` (covered by `Bash(gh pr comment:*)`)

This dead permission widens the blast radius of a potential prompt injection attack via malicious PR titles, commit messages, or CI check names embedded in the shepherd's context. Removing it reduces the attack surface with no functional impact.

Closes #348

Generated with [Claude Code](https://claude.ai/code)