### PR TITLE
fix: scope Bash(gh api:*) to review and comment endpoints in pr-shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh api repos/*/issues/*/comments:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
           prompt: |
             You are a PR shepherd for the repo ${{ github.repository }}.
 


### PR DESCRIPTION
Replace overly broad `Bash(gh api:*)` in `claude-pr-shepherd.yml` with two least-privilege patterns that match only the endpoints the shepherd actually calls:

- `Bash(gh api repos/*/pulls/*/reviews:*)` — for reading review approval/CHANGES_REQUESTED timestamps
- `Bash(gh api repos/*/issues/*/comments:*)` — for reading comment timestamps used in de-dup logic

This follows the principle of least privilege, consistent with the fix applied in #347 for `claude-self-improve.yml`, and removes the risk of the shepherd inadvertently (or via prompt injection) calling destructive endpoints such as `DELETE /repos/.../git/refs/...` or `PATCH /repos/.../pulls/...`.

Closes #354

Generated with [Claude Code](https://claude.ai/code)