### PR TITLE
fix: narrow changelog-skipped search to titles only

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -113,7 +113,7 @@ jobs:
 
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:
-              gh issue list --state open --search "Changelog skipped" --limit 50
+              gh issue list --state open --search "Changelog skipped for in:title" --limit 50
             Count the results. If 2 or more open "Changelog skipped" issues exist, first
             check whether a batch-changelog run is already queued or in progress:
               gh run list --workflow=batch-changelog.yml --json status --limit 10

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -85,7 +85,7 @@ jobs:
 
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:
-              gh issue list --state open --search "Changelog skipped" --limit 50
+              gh issue list --state open --search "Changelog skipped for in:title" --limit 50
             Count the results. If 2 or more open "Changelog skipped" issues exist, first
             check whether a batch-changelog run is already queued or in progress:
               gh run list --workflow=batch-changelog.yml --json status --limit 10


### PR DESCRIPTION
Append `in:title` to the GitHub search query in both `claude-proactive.yml` and `claude-self-improve.yml` so only issues whose **titles** contain "Changelog skipped for" are matched.

Previously, `gh issue list --search "Changelog skipped"` matched issue bodies too, causing false positives (e.g. issues #213, #301, #335 that discuss the auto-tag failure scenario in their body text). This inflated the count above the 2-issue threshold and would repeatedly (and incorrectly) dispatch `batch-changelog.yml` on every scan run once those guard PRs merged.

### Changes
- `.github/workflows/claude-proactive.yml`: `search "Changelog skipped"` → `search "Changelog skipped for in:title"`
- `.github/workflows/claude-self-improve.yml`: same change

Closes #353

Generated with [Claude Code](https://claude.ai/code)