### PR TITLE
fix: use two wildcards for owner/repo in gh api allowedTools patterns

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh api repos/*/issues/*/comments:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh api repos/*/*/issues/*/comments:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
           prompt: |
             You are a PR shepherd for the repo ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary

The `Bash(gh api:*)` allowed-tools patterns in `claude-pr-shepherd.yml` used single wildcards (`*`) for the owner/repo portion of GitHub API paths. Since `*` does not match `/`, paths like `repos/greynewell/claude-software-factory/pulls/123/reviews` could never match, blocking all `gh api` calls.

**Before:**
```
Bash(gh api repos/*/pulls/*/reviews:*),Bash(gh api repos/*/issues/*/comments:*)
```

**After:**
```
Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh api repos/*/*/issues/*/comments:*)
```

This matches the pattern already used correctly in `claude-proactive.yml`.

Closes #358

Generated with [Claude Code](https://claude.ai/code)