### PR TITLE
fix: scope Bash(gh api:*) to review and checks endpoints in claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh pr checks:*),Read,Glob,Grep"'
           prompt: |
             Review this pull request for:
             1. Correctness and logic errors


### PR DESCRIPTION
Replace overly broad Bash(gh api:*) with Bash(gh api repos/*/*/pulls/*/reviews:*) to restrict the reviewer agent to only the PR review submission endpoint. Also adds Bash(gh pr checks:*) as required for the CI gate prereq referenced in issues #221 and #326.

## Changes
- claude-code-review.yml line 28: Bash(gh api:*) replaced with Bash(gh api repos/*/*/pulls/*/reviews:*) and Bash(gh pr checks:*) added

This follows the same pattern already used in claude-proactive.yml and claude-pr-shepherd.yml.

Closes #359

Generated with [Claude Code](https://claude.ai/code)