### PR TITLE
fix: extend step 6c de-dup to re-trigger review on claude-code-review FAILURE

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -109,7 +109,12 @@ jobs:
                   - Get the timestamp of the most recent "please review this PR" comment:
                     Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '[.[] | select(.body | contains("please review this PR"))] | max_by(.created_at) | .created_at'
                     (Returns an ISO timestamp string, or null if no such comment exists)
-                  - If the most recent "please review this PR" comment timestamp is non-empty AND is more recent than (or equal to) the last commit timestamp, skip to the next PR without posting (de-dup: the existing trigger was already posted after the latest push).
+                  - If the most recent "please review this PR" comment timestamp is non-empty AND is more recent than (or equal to) the last commit timestamp:
+                    - The re-trigger comment was already posted for this push. Before skipping, check whether the review workflow actually succeeded.
+                    - Get the current state of the claude-code-review check:
+                      Run: gh pr checks <number> --repo ${{ github.repository }} --json name,state --jq '[.[] | select(.name == "claude-code-review")] | .[0].state // "MISSING"'
+                    - If the claude-code-review check state is "FAILURE", do NOT skip — the previous re-trigger attempt failed (e.g. wrong bot triggered, rate limit, API error). Fall through to post another re-trigger comment below.
+                    - Otherwise (state is SUCCESS, IN_PROGRESS, PENDING, or MISSING), skip to the next PR without posting (de-dup: the existing trigger was already posted after the latest push and the review is in progress or completed).
                   - Otherwise (no such comment exists, OR the comment predates the latest commit push), post a comment to re-trigger the review workflow:
                     gh pr comment <number> --repo ${{ github.repository }} --body "@claude please review this PR and submit a formal review decision (APPROVE or REQUEST_CHANGES)."
                d. Otherwise (commit is less than 2 hours old), skip and wait for the review workflow to complete.


### PR DESCRIPTION
## Summary

Fixes the permanent block in the PR shepherd's de-dup logic when the `claude-code-review` workflow fails after a re-trigger comment has been posted.

### Problem

In step 6c, the shepherd posts a `@claude please review this PR` comment to re-trigger code review, then de-duplicates future runs by checking if the comment is newer than the last commit. This assumes the review will eventually succeed — but if the review workflow fails (wrong bot triggered, rate limit, API error), the `claude-code-review` check stays in FAILURE and the shepherd never re-triggers again until a new commit is pushed.

### Fix

Extended the de-dup check: after confirming the re-trigger comment is newer than the last commit, also check the `claude-code-review` check state. If it is `FAILURE`, skip the de-dup and allow posting another re-trigger comment. Only skip (de-dup) when the check is in `SUCCESS`, `IN_PROGRESS`, `PENDING`, or `MISSING` state.

This directly addresses both failure scenarios from the issue:
1. Wrong bot triggered (issue #80) — review check stays FAILURE → shepherd re-triggers
2. claude-code-review.yml itself fails — review check stays FAILURE → shepherd re-triggers

Closes #363

Generated with [Claude Code](https://claude.ai/code)