### PR TITLE
fix: add QUEUED to CI-still-running states in pr-shepherd step 1

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -38,7 +38,7 @@ jobs:
                If none of the label objects in the labels array has name equal to "claude-task", skip ALL remaining steps for this PR immediately — do not post any comments, do not check CI, do not check conflicts, do not request reviews, do not attempt to merge. Move on to the next PR.
             1. Check CI: Run gh pr checks <number> --repo ${{ github.repository }} and evaluate the output carefully before proceeding:
                - If the output is empty (no checks listed), CI has not started yet → SKIP this PR entirely, do not merge
-               - If any check shows a status of "PENDING" or "IN_PROGRESS", CI is still running → SKIP this PR, do not merge
+               - If any check shows a status of "PENDING", "IN_PROGRESS", or "QUEUED", CI is still running or not yet started → SKIP this PR entirely, do not merge
                - If any check shows a status of "FAILURE", "CANCELLED", "TIMED_OUT", or "ACTION_REQUIRED", CI has failed → do NOT merge; instead apply timestamp-aware de-dup:
                  Get the timestamp of the most recent "CI checks are failing" comment:
                    Run: gh api repos/${{ github.repository }}/issues/<number>/comments --jq '[.[] | select(.body | contains("CI checks are failing"))] | max_by(.created_at) | .created_at'


### PR DESCRIPTION
## Summary

In `.github/workflows/claude-pr-shepherd.yml`, step 1 handled `PENDING` and `IN_PROGRESS` as CI-still-running states that cause an early skip, but `QUEUED` was missing. Checks in `QUEUED` state (created but not yet started) fell through to steps 2–3, potentially posting spurious merge-conflict comments before CI had even begun.

## Change

Updated the step 1 clause to include `QUEUED` alongside `PENDING` and `IN_PROGRESS`:

```
- If any check shows a status of "PENDING", "IN_PROGRESS", or "QUEUED", CI is still
  running or not yet started → SKIP this PR entirely, do not merge
```

This ensures QUEUED checks are handled consistently with PENDING/IN_PROGRESS at the earliest possible step, preventing unnecessary downstream processing.

Closes #375

Generated with [Claude Code](https://claude.ai/code)