### PR TITLE
fix: treat CANCELLED and TIMED_OUT as retriggerable in shepherd step 6c

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -113,7 +113,7 @@ jobs:
                     - The re-trigger comment was already posted for this push. Before skipping, check whether the review workflow actually succeeded.
                     - Get the current state of the claude-code-review check:
                       Run: gh pr checks <number> --repo ${{ github.repository }} --json name,state --jq '[.[] | select(.name == "claude-code-review")] | .[0].state // "MISSING"'
-                    - If the claude-code-review check state is "FAILURE", do NOT skip — the previous re-trigger attempt failed (e.g. wrong bot triggered, rate limit, API error). Fall through to post another re-trigger comment below.
+                    - If the claude-code-review check state is "FAILURE", "CANCELLED", or "TIMED_OUT", do NOT skip — the previous re-trigger attempt failed or was cancelled (e.g. wrong bot triggered, rate limit, API error, infrastructure cancellation). Fall through to post another re-trigger comment below.
                     - Otherwise (state is SUCCESS, IN_PROGRESS, PENDING, or MISSING), skip to the next PR without posting (de-dup: the existing trigger was already posted after the latest push and the review is in progress or completed).
                   - Otherwise (no such comment exists, OR the comment predates the latest commit push), post a comment to re-trigger the review workflow:
                     gh pr comment <number> --repo ${{ github.repository }} --body "@claude please review this PR and submit a formal review decision (APPROVE or REQUEST_CHANGES)."


### PR DESCRIPTION
## Summary

In claude-pr-shepherd.yml step 6c, the de-dup logic only re-triggered the claude-code-review workflow when the check state was FAILURE. States CANCELLED and TIMED_OUT were silently treated as healthy (falling into the otherwise-skip branch), which left PRs without a review indefinitely after infrastructure-level cancellations not caused by a new push.

### Change

Updated the condition to treat CANCELLED and TIMED_OUT identically to FAILURE -- both now fall through to post a re-trigger comment.

Before:
- FAILURE -> re-trigger
- SUCCESS, IN_PROGRESS, PENDING, MISSING, CANCELLED, TIMED_OUT -> skip (silent bug)

After:
- FAILURE, CANCELLED, TIMED_OUT -> re-trigger
- SUCCESS, IN_PROGRESS, PENDING, MISSING -> skip (correct)

Note: cancellations caused by cancel-in-progress: true (new push) are still self-healing since the synchronize event fires a new review run automatically.

Closes #378

Generated with [Claude Code](https://claude.ai/code)