### PR TITLE
fix: add root-cause shepherd search before filing CHANGES_REQUESTED stuck-PR issues

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -110,11 +110,19 @@ jobs:
               "IN_PROGRESS", or "QUEUED" — a failing or in-progress CI is a legitimate reason
               the shepherd has not merged yet. Only flag a PR as stuck if all checks are passing
               (state "SUCCESS") but the PR still has not been merged.
-            - Any PR whose reviewDecision is CHANGES_REQUESTED and has been open > 2 days (the
-              shepherd may not be re-requesting a review after the author pushes a fix — check
-              whether claude-pr-shepherd.yml correctly handles stale CHANGES_REQUESTED reviews
-              and whether the merge step is reached after CHANGES_REQUESTED resolves);
-              include the PR number, title, and age in days in the filed issue body
+            - Any PR whose reviewDecision is CHANGES_REQUESTED and has been open > 2 days:
+              Before filing a per-PR stuck issue, first run a root-cause shepherd search:
+                gh issue list --state open --search "shepherd CHANGES_REQUESTED" --limit 5
+              If one or more results are returned, a root-cause issue already tracks the underlying
+              shepherd bug — do NOT file a new per-PR issue. Instead, add a comment to the most
+              relevant existing issue (pick the one whose title best matches the shepherd/CHANGES_REQUESTED
+              theme) with the PR number, title, and age in days:
+                gh issue comment <issue_number> --body "PR #<pr_number> (<pr_title>) has been stuck in CHANGES_REQUESTED for <age> days."
+              Only file a new per-PR stuck issue if no shepherd-CHANGES_REQUESTED root-cause issue is
+              open. When filing, include the PR number, title, and age in days in the issue body.
+              (Background: the shepherd may not be re-requesting a review after the author pushes a
+              fix — check whether claude-pr-shepherd.yml correctly handles stale CHANGES_REQUESTED
+              reviews and whether the merge step is reached after CHANGES_REQUESTED resolves.)
 
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -86,6 +86,11 @@ jobs:
             - Any failure patterns in CI that the factory itself could detect proactively
             - Workflows with a high failure rate (e.g., claude-pr-shepherd.yml or claude-proactive.yml
               failing systematically), which may indicate a broken trigger, permission gap, or config issue
+            If the analysis surfaces PRs stuck in CHANGES_REQUESTED (reviewDecision == CHANGES_REQUESTED,
+            open > 2 days), apply the same root-cause guard used by the hourly scanner before filing:
+              gh issue list --state open --search "shepherd CHANGES_REQUESTED" --limit 5
+            If a root-cause shepherd issue already exists, comment on it with the PR details instead
+            of filing a new per-PR symptom issue.
 
             **Changelog skipped issue recovery**:
             Check for accumulated "Changelog skipped" issues by running:


### PR DESCRIPTION
## Summary

Before filing a per-PR stuck issue for `CHANGES_REQUESTED` PRs open > 2 days, the proactive scanner now first searches for an existing root-cause shepherd issue:

```
gh issue list --state open --search "shepherd CHANGES_REQUESTED" --limit 5
```

**If a root-cause issue is found**: comment on the most relevant existing issue with the PR number, title, and age in days — no new issue is filed.

**If no root-cause issue is found**: file the per-PR stuck issue as before.

The same guard is added to `claude-self-improve.yml` Pass 4 to prevent the weekly scanner from filing per-PR symptom issues when a root-cause issue already exists.

## Files changed

- `.github/workflows/claude-proactive.yml` — expanded CHANGES_REQUESTED bullet with root-cause search step
- `.github/workflows/claude-self-improve.yml` — added root-cause guard note in Pass 4 PR health section

Closes #385

Generated with [Claude Code](https://claude.ai/code)
