### PR TITLE
fix: remove unused git and file-reading tools from shepherd allowedTools

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh api repos/*/*/issues/*/comments:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh api repos/*/*/issues/*/comments:*)"'
           prompt: |
             You are a PR shepherd for the repo ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary

Remove seven unused tools from `claude-pr-shepherd.yml` allowedTools to reduce attack surface:

- `Bash(git fetch:*)`
- `Bash(git log:*)`
- `Bash(git diff:*)`
- `Bash(git status:*)`
- `Read`
- `Glob`
- `Grep`

These tools are never invoked by the shepherd prompt — all actions use `gh pr` and `gh api` commands. Removing them shrinks the tool surface that could be exploited via prompt injection from user-controlled PR content (titles, CI output messages, etc.).

The retained tools are: `Bash(gh pr list:*)`, `Bash(gh pr view:*)`, `Bash(gh pr checks:*)`, `Bash(gh pr merge:*)`, `Bash(gh pr comment:*)`, `Bash(gh pr review:*)`, `Bash(gh api repos/*/*/pulls/*/reviews:*)`, `Bash(gh api repos/*/*/issues/*/comments:*)`.

Closes #384

Generated with [Claude Code](https://claude.ai/code)