### PR TITLE
fix: add Bash(gh issue comment:*) to claude-proactive.yml allowedTools

### DIFF
--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -25,7 +25,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           allowed_bots: "claude[bot],github-actions[bot]"
-          claude_args: '--allowedTools "Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
+          claude_args: '--allowedTools "Bash(gh api repos/*/*/pulls/*/reviews:*),Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue comment:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh workflow run batch-changelog.yml:*),Bash(date:*),Read,Glob,Grep"'
           prompt: |
             You are the Claude Software Factory scanning itself for improvements. This repo IS
             the factory — its workflows are the product. Improving them is the primary goal.


### PR DESCRIPTION
## Summary

The hourly proactive scanner prompt has logic to avoid duplicate issues when a CHANGES_REQUESTED PR is stuck: it searches for existing root-cause shepherd issues and, if found, posts a comment via `gh issue comment` instead of filing a new per-PR issue.

However, `Bash(gh issue comment:*)` was missing from the `allowedTools` list, so that dedup comment path silently failed — and since `Bash(gh issue create:*)` *was* allowed, Claude would fall back to creating duplicate issues anyway.

**Change**: Added `Bash(gh issue comment:*)` to the `allowedTools` list in `.github/workflows/claude-proactive.yml`, immediately after `Bash(gh issue create:*)`.

Closes #389

Generated with [Claude Code](https://claude.ai/code)